### PR TITLE
Fixes to Issue #33, #91, #110, and #115

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ src/www/static/docs
 src/config_prod.py
 src/run/*.pickle
 src/run/done/*.pickle
+src/.idea/

--- a/src/hub/dataload/sources/cadd/cadd_parser.py
+++ b/src/hub/dataload/sources/cadd/cadd_parser.py
@@ -210,5 +210,5 @@ def fetch_generator(tabix, contig):
 
 def load_data(data_folder):
     for contig in [i for i in range(1,24)] + ["X","Y"]:
-        load_contig(config)
+        load_contig(contig)
 

--- a/src/hub/dataload/sources/clingen/upload.py
+++ b/src/hub/dataload/sources/clingen/upload.py
@@ -1,5 +1,6 @@
 import os, glob
 
+from hub.dataload.storage import MyVariantBasicStorage
 import biothings.hub.dataload.uploader as uploader
 from .parser import load_data
 
@@ -17,6 +18,8 @@ class ClingenUploader(uploader.ParallelizedSourceUploader):
             }
 
     GLOB_PATTERN = "mvi_ca.split.*"
+
+    storage_class = MyVariantBasicStorage
 
     def jobs(self):
         # tuple(input_file,) (only one arg, but still need a tuple

--- a/src/hub/dataload/sources/clingen/upload.py
+++ b/src/hub/dataload/sources/clingen/upload.py
@@ -7,15 +7,16 @@ from .parser import load_data
 
 class ClingenUploader(uploader.ParallelizedSourceUploader):
     name = "clingen"
-    __metadata__ = {"mapper": 'observed',
-            "assembly": "hg38",
-            "src_meta": {
-                "url": "https://www.clinicalgenome.org",
-                "license_url": "https://www.clinicalgenome.org/about/terms-of-use",
-                "license_url_short": "http://bit.ly/2kAtyoH",
-                "licence": "CC0 1.0 Universal",
-                }
-            }
+    __metadata__ = {
+        "mapper": 'observed',
+        "assembly": "hg38",
+        "src_meta": {
+            "url": "https://www.clinicalgenome.org",
+            "license_url": "https://www.clinicalgenome.org/about/terms-of-use",
+            "license_url_short": "http://bit.ly/2kAtyoH",
+            "licence": "CC0 1.0 Universal",
+        }
+    }
 
     GLOB_PATTERN = "mvi_ca.split.*"
 
@@ -26,7 +27,7 @@ class ClingenUploader(uploader.ParallelizedSourceUploader):
         return map(lambda e: (e, ),
                    glob.glob(os.path.join(self.data_folder, self.__class__.GLOB_PATTERN)))
 
-    def load_data(self,input_file):
+    def load_data(self, input_file):
         # there's one vcf file there, let's get it
         assert os.path.exists(input_file), "Can't find input file '%s'" % input_file
         self.logger.info("Load data from file '%s'" % input_file)

--- a/src/hub/dataload/sources/clinvar/clinvar_upload.py
+++ b/src/hub/dataload/sources/clinvar/clinvar_upload.py
@@ -1,19 +1,22 @@
 from .clinvar_xml_parser import load_data as load_common
 from hub.dataload.uploader import SnpeffPostUpdateUploader
+from hub.dataload.storage import MyVariantTrimmingStorage
 
 
 SRC_META = {
-        "url" : "https://www.ncbi.nlm.nih.gov/clinvar/",
-        "license_url" : "https://www.ncbi.nlm.nih.gov/clinvar/intro/",
-        "license_url_short": "http://bit.ly/2SQdcI0"
-        }
+    "url": "https://www.ncbi.nlm.nih.gov/clinvar/",
+    "license_url": "https://www.ncbi.nlm.nih.gov/clinvar/intro/",
+    "license_url_short": "http://bit.ly/2SQdcI0"
+}
+
 
 class ClinvarBaseUploader(SnpeffPostUpdateUploader):
+    storage_class = MyVariantTrimmingStorage
 
     def get_pinfo(self):
         pinfo = super(ClinvarBaseUploader,self).get_pinfo()
         # clinvar parser has some memory requirements, ~1.5G
-        pinfo.setdefault("__reqs__",{})["mem"] = 1.5 * (1024**3)
+        pinfo.setdefault("__reqs__", {})["mem"] = 1.5 * (1024**3)
         return pinfo
 
     @classmethod
@@ -223,18 +226,18 @@ class ClinvarHG19Uploader(ClinvarBaseUploader):
     name = "clinvar_hg19"
     main_source = "clinvar"
     __metadata__ = {
-            "mapper" : 'observed_skipidtoolong',
-            "assembly" : "hg19",
-            "src_meta" : SRC_META,
-            }
+        "mapper": 'observed_skipidtoolong',
+        "assembly": "hg19",
+        "src_meta": SRC_META,
+    }
 
-    def load_data(self,data_folder):
+    def load_data(self, data_folder):
         self.logger.info("Load data from folder '%s'" % data_folder)
         try:
-            return load_common(data_folder,"hg19")
+            return load_common(data_folder, "hg19")
         except Exception as e:
             import traceback
-            self.logger.error("Error while uploading, %s:\n%s" % (e,traceback.format_exc()))
+            self.logger.error("Error while uploading, %s:\n%s" % (e, traceback.format_exc()))
             raise
 
 
@@ -243,17 +246,16 @@ class ClinvarHG38Uploader(ClinvarBaseUploader):
     name = "clinvar_hg38"
     main_source = "clinvar"
     __metadata__ = {
-            "mapper" : 'observed_skipidtoolong',
-            "assembly" : "hg38",
-            "src_meta" : SRC_META,
-            }
+        "mapper": 'observed_skipidtoolong',
+        "assembly": "hg38",
+        "src_meta": SRC_META,
+    }
 
-    def load_data(self,data_folder):
+    def load_data(self, data_folder):
         self.logger.info("Load data from folder '%s'" % data_folder)
         try:
-            return load_common(data_folder,"hg38")
+            return load_common(data_folder, "hg38")
         except Exception as e:
             import traceback
             self.logger.error("Error while uploading, %s:\n%s" % (e,traceback.format_exc()))
             raise
-

--- a/src/hub/dataload/sources/wellderly/__init__.py
+++ b/src/hub/dataload/sources/wellderly/__init__.py
@@ -1,2 +1,3 @@
-from .wellderly_upload import WellderlyFactoryUploader
+from .wellderly_dumper import WellderlyDumper
+from .wellderly_upload import WellderlyUploader
 

--- a/src/hub/dataload/sources/wellderly/wellderly_dumper.py
+++ b/src/hub/dataload/sources/wellderly/wellderly_dumper.py
@@ -1,0 +1,15 @@
+import os
+import biothings, config
+biothings.config_for_app(config)
+
+from config import DATA_ARCHIVE_ROOT
+from biothings.hub.dataload.dumper import ManualDumper
+
+class WellderlyDumper(ManualDumper):
+
+    SRC_NAME = "wellderly"
+    SRC_ROOT_FOLDER = os.path.join(DATA_ARCHIVE_ROOT, SRC_NAME)
+
+    def __init__(self, *args, **kwargs):
+        super(WellderlyDumper, self).__init__(*args, **kwargs)
+        self.logger.info("Assuming Wellderly.chr*.g.vcf.gz.tsv files were manual downloaded")

--- a/src/hub/dataload/sources/wellderly/wellderly_dumper.py
+++ b/src/hub/dataload/sources/wellderly/wellderly_dumper.py
@@ -5,6 +5,7 @@ biothings.config_for_app(config)
 from config import DATA_ARCHIVE_ROOT
 from biothings.hub.dataload.dumper import ManualDumper
 
+
 class WellderlyDumper(ManualDumper):
 
     SRC_NAME = "wellderly"

--- a/src/hub/dataload/sources/wellderly/wellderly_parser.py
+++ b/src/hub/dataload/sources/wellderly/wellderly_parser.py
@@ -1,0 +1,356 @@
+import pandas as pd
+from collections import namedtuple, Counter
+from itertools import combinations_with_replacement as cwr
+
+
+class Genotype:
+    def __init__(self, first_allele, second_allele):
+        self.first_allele = first_allele
+        self.second_allele = second_allele
+
+    def __str__(self):
+        return "{}/{}".format(self.first_allele, self.second_allele)
+
+# (`start`, `end`) can be different from `pos`
+# E.g `chr1:g.10429_10433del` with a genotype `CCCTAA/C`, has pos == 10428, start == 10429 and end == 10433
+HgvsID = namedtuple('HgvsID', ['_id', 'chrom', 'start', 'end', 'vartype'])
+
+
+class MyVariantUtil:
+    """
+    Originally from https://github.com/biothings/biothings_client.py/blob/092ffa1e1e35fbee2c9b7eb5defbee160697e3d8/biothings_client/mixins/variant.py
+
+    Adapted the following two methods to @classmethod's
+
+    Also returned `chrom`, `start`, `end`, `vartype` in `format_hgvs()`
+    """
+
+    @classmethod
+    def _normalized_vcf(cls, chrom, pos, ref, alt):
+        """If both ref/alt are > 1 base, and there are overlapping from the left,
+           we need to trim off the overlapping bases.
+           In the case that ref/alt is like this:
+               CTTTT/CT    # with >1 overlapping bases from the left
+           ref/alt should be normalized as TTTT/T, more examples:
+                TC/TG --> C/G
+           and pos should be fixed as well.
+        """
+        for i in range(max(len(ref), len(alt))):
+            _ref = ref[i] if i < len(ref) else None
+            _alt = alt[i] if i < len(alt) else None
+            if _ref is None or _alt is None or _ref != _alt:
+                break
+
+        # _ref/_alt cannot be both None, if so,
+        # ref and alt are exactly the same,
+        # something is wrong with this VCF record
+        # assert not (_ref is None and _alt is None)
+        if _ref is None and _alt is None:
+            raise ValueError('"ref" and "alt" cannot be the same: {}'.format((chrom, pos, ref, alt)))
+
+        _pos = int(pos)
+        if _ref is None or _alt is None:
+            # if either is None, del or ins types
+            _pos = _pos + i - 1
+            _ref = ref[i-1:]
+            _alt = alt[i-1:]
+        else:
+            # both _ref/_alt are not None
+            _pos = _pos + i
+            _ref = ref[i:]
+            _alt = alt[i:]
+
+        return chrom, _pos, _ref, _alt
+
+    @classmethod
+    def format_hgvs(cls, chrom, pos, ref, alt):
+        """get a valid hgvs name from VCF-style "chrom, pos, ref, alt" data.
+        Example:
+            >>> MyVariantUtil.format_hgvs("1", 35366, "C", "T")
+            >>> MyVariantUtil.format_hgvs("2", 17142, "G", "GA")
+            >>> MyVariantUtil.format_hgvs("MT", 8270, "CACCCCCTCT", "C")
+            >>> MyVariantUtil.format_hgvs("X", 107930849, "GGA", "C")
+        """
+        chrom, pos = str(chrom), int(pos)
+        if chrom.lower().startswith('chr'):
+            # trim off leading "chr" if any
+            chrom = chrom[3:]
+
+        # python integer range is from -2,147,483,648 to 2,147,483,647
+        # The max sequence length is on chr1 (GRCh37.p13), 249,250,621
+        pos = int(pos)
+
+        if len(ref) == len(alt) == 1:
+            # this is a SNP
+            _id = 'chr{0}:g.{1}{2}>{3}'.format(chrom, pos, ref, alt)
+            return HgvsID(_id=_id, chrom=chrom, start=pos, end=pos, vartype="snp")
+
+        if len(ref) > 1 and len(alt) == 1:
+            # this is a deletion:
+            if ref[0] == alt:
+                start = pos + 1
+                end = pos + len(ref) - 1
+
+                if start == end:
+                    _id = 'chr{0}:g.{1}del'.format(chrom, start)
+                else:
+                    _id = 'chr{0}:g.{1}_{2}del'.format(chrom, start, end)
+                return HgvsID(_id=_id, chrom=chrom, start=start, end=end, vartype="del")
+            else:
+                start = pos
+                end = start + len(ref) - 1
+
+                _id = 'chr{0}:g.{1}_{2}delins{3}'.format(chrom, start, end, alt)
+                return HgvsID(_id=_id, chrom=chrom, start=start, end=end, vartype="delins")
+
+        if len(ref) == 1 and len(alt) > 1:
+            # this is an insertion
+            if alt[0] == ref:
+                start, end = pos, pos + 1
+                ins_seq = alt[1:]
+
+                _id = 'chr{0}:g.{1}_{2}ins{3}'.format(chrom, start, end, ins_seq)
+                return HgvsID(_id=_id, chrom=chrom, start=start, end=end, vartype="ins")
+            else:
+                _id = 'chr{0}:g.{1}delins{2}'.format(chrom, pos, alt)
+                return HgvsID(_id=_id, chrom=chrom, start=pos, end=pos, vartype="delins")
+
+        if len(ref) > 1 and len(alt) > 1:
+            if ref[0] == alt[0]:
+                # if ref and alt overlap from the left, trim them first
+                _chrom, _pos, _ref, _alt = cls._normalized_vcf(chrom, pos, ref, alt)
+                return cls.format_hgvs(_chrom, _pos, _ref, _alt)
+            else:
+                start, end = pos, pos + len(alt) - 1
+
+                _id = 'chr{0}:g.{1}_{2}delins{3}'.format(chrom, start, end, alt)
+                return HgvsID(_id=_id, chrom=chrom, start=start, end=end, vartype="delins")
+
+        raise ValueError("Cannot convert {} into HGVS id.".format((chrom, pos, ref, alt)))
+
+
+# class HardyWeinbergHelper:
+#     def __init__(self, allele_cnt=10):
+#         if allele_cnt < 1:
+#             raise ValueError("Meaningless count of alleles. Got allele_cnt={}".format(allele_cnt))
+#
+#         self.allele_cnt = allele_cnt
+#         self.hist_of_diploid_genotype_cnt = [self.n_combinations(n, 2, with_replacement=True)
+#                                              for n in range(0, allele_cnt + 1)]
+#
+#     def gc_index(self, nth_alt):
+#         """
+#         The `GC` column (not VCF-standard) in the Wellderly tsv files seems to represent the count of genotypes in the
+#         following patterns.
+#
+#         Suppose a, b, c, ..., z represent the allele frequencies.
+#
+#         For n = 2 alleles, the genotype frequencies are expanded as (a+b)^2 = a^2 + 2ab + b^2. Therefore, e.g. given
+#         REF = A, ALT = T and GC = "1157,23,1", we have number of genotype AA = 1157, AT = 23 and TT = 1. This splitting
+#         pattern must be consistent to the `AC` column (VCF-standard; allele count in genotypes, for each ALT allele,
+#         in the same order as listed). E.g. for the above case, the `AC` field for allele T must be 25
+#         (23 in AT plus 2 in TT).
+#
+#         For n = 3 alleles, expanded as (a+b+c)^2 = (a+b)^2 + 2(a+b)c + c^2 = a^2 + 2ab + b^2 + 2ac + 2bc + c^2
+#         For n = 4 alleles, expanded as (a+b+c+d)^2 = (a+b+c)^2 + 2(a+b+c)d + d^2 = ...
+#         ...
+#
+#         Therefore, the length of a `GC` field is exactly the number of genotypes for that exact row in a Wallderly tsv
+#         file. And no matter how long it is, given a fixed REF allele (whose frequency is 'a')
+#
+#         - For the 1st ALT allele (whose frequency is 'b'), the genotype counts are GC[0], GC[1] and GC[2]
+#         - For the 2nd ALT allele (whose frequency is 'c'), the genotype counts are GC[0], GC[3] and GC[5]
+#         - For the 3rd ALT allele (whose frequency is 'd'), the genotype counts are GC[0], GC[6] and GC[9]
+#         - ...
+#
+#         The index of genotype counts in GC for n-th ALT alleles can be computed from the pre-computed
+#         `self.hist_of_diploid_genotype_cnt`:
+#
+#                              nth_alt =        1, 2, 3,  4,  5,  6,  ...
+#                           allele_cnt =     1, 2, 3, 4,  5,  6,  7,  ...
+#         hist_of_diploid_genotype_cnt = [0, 1, 3, 6, 10, 15, 21, 28, ...]
+#         """
+#
+#         if nth_alt < 1:
+#             raise ValueError("Meaningless order of ALT alleles. Got nth_alt={}".format(nth_alt))
+#
+#         if nth_alt >= self.allele_cnt:
+#             # Dynamically expanding the histogram
+#             updated_allele_cnt = nth_alt + 1
+#             self.hist_of_diploid_genotype_cnt += [self.n_combinations(n, 2, with_replacement=True)
+#                                                   for n in range(self.allele_cnt + 1, updated_allele_cnt + 1)]
+#             self.allele_cnt = updated_allele_cnt
+#
+#         return 0, self.hist_of_diploid_genotype_cnt[nth_alt], self.hist_of_diploid_genotype_cnt[nth_alt+1] - 1
+#
+#     @classmethod
+#     def choose(cls, n, k):
+#         """
+#         A fast way to calculate binomial coefficients.
+#
+#         Originally from https://stackoverflow.com/a/3025547
+#         """
+#         if 0 <= k <= n:
+#             """
+#             Due to the symmetry, (n choose k) == (n choose (n-k)).
+#
+#             Suppose k is small, after the loop:
+#
+#             - numerator = n * (n-1) * ... * (n-(k-1))
+#             - denominator = k * (k-1) * ... * 2 * 1
+#             """
+#             numerator = 1
+#             denominator = 1
+#             for t in range(1, min(k, n - k) + 1):
+#                 numerator *= n
+#                 denominator *= t
+#                 n -= 1
+#             return numerator // denominator
+#         else:
+#             return 0
+#
+#     @classmethod
+#     def n_combinations(cls, n, k, with_replacement=False):
+#         """
+#         Number of combinations when drawing k items out of n.
+#         """
+#         if not with_replacement:
+#             return cls.choose(n, k)
+#         else:
+#             return cls.choose(n + k - 1, k)
+
+class HardyWeinbergHelper:
+    @classmethod
+    def genotype_combinations(cls, ref: str, alt_list: list) -> list:
+        """
+        The `GC` column (not VCF-standard) in the Wellderly tsv files seems to represent the count of genotypes in the
+        following patterns.
+
+        Suppose a, b, c, ..., z represent the allele frequencies.
+
+        For n = 2 alleles, the genotype frequencies are expanded as (a+b)^2 = a^2 + 2ab + b^2. Therefore, e.g. given
+        REF = A, ALT = T and GC = "1157,23,1", we have number of genotype AA = 1157, AT = 23 and TT = 1. This splitting
+        pattern must be consistent to the `AC` column (VCF-standard; allele count in genotypes, for each ALT allele,
+        in the same order as listed). E.g. for the above case, the `AC` field for allele T must be 25
+        (23 in AT plus 2 in TT).
+
+        For n = 3 alleles, expanded as (a+b+c)^2 = (a+b)^2 + 2(a+b)c + c^2 = a^2 + 2ab + b^2 + 2ac + 2bc + c^2
+        For n = 4 alleles, expanded as (a+b+c+d)^2 = (a+b+c)^2 + 2(a+b+c)d + d^2 = ...
+        ...
+
+        Note that this expanding scheme seems only apply to the Wellderly tsv files.
+
+        For n alleles, there would be {(n+1) choose 2} genotypes regardless of the combination order.
+        """
+        # The REF must be the first allele in the list
+        allele_list = [ref] + alt_list
+        genotype_list = [Genotype(first_allele=q, second_allele=p) for (p, q) in cwr(reversed(allele_list), 2)]
+        genotype_list.reverse()
+        return genotype_list
+
+    @classmethod
+    def check_count_constraint(cls, genotype_list: list, genotype_cnt: list, alt_list: list, alt_cnt: list,
+                               check_genotype_length=False, check_alt_length=False):
+        """
+        Check if the `GC` and `AC` columns are consistent with the genotype combination
+
+        `genotype_cnt`, `alt_list` and `alt_cnt` are directly parsed from the `GC`, `ALT` and `AC` columns respectively.
+
+        - GC is not a VCF-standard field
+        - ALT - VCF-standard; alternate base(s): comma-separated list of alternate non-reference alleles.
+        - AC - VCF-standard; allele count in genotypes, for each ALT allele, in the same order as listed
+
+        See https://samtools.github.io/hts-specs/VCFv4.3.pdf for more information about these two fields
+
+        `genotype_list` and `genotype_cnt` should be of the same length;
+        `alt_list` and `alt_cnt` must be of the same length by definition.
+
+        E.g. given REF = C, ALT = [G, T], AC = [3, 2], GC = [78, 3, 0, 0, 0, 1], the genotype combinations must be
+        ['C/C', 'C/G', 'G/G', 'C/T', 'G/T', 'T/T'] and the AC numbers constraint must be met.
+
+        | Genotype | GC | num of 'G' | num of 'T' |
+        |:--------:|:--:|:----------:|:----------:|
+        |    C/C   | 78 |      0     |      0     |
+        |    C/G   |  3 |      3     |      0     |
+        |    G/G   |  0 |      0     |      0     |
+        |    C/T   |  0 |      0     |      0     |
+        |    G/T   |  0 |      0     |      0     |
+        |    T/T   |  1 |      0     |      2     |
+        |    ---   |  - |      -     |      -     |
+        |    AC    |  - |      3     |      2     |
+        """
+
+        if check_genotype_length:
+            if len(genotype_list) != len(genotype_cnt):
+                raise ValueError("Inconsistent genotype lengths. Got genotype_list={}, genotype_cnt={}".
+                                 format(genotype_list, genotype_cnt))
+
+        if check_alt_length:
+            if len(alt_list) != len(alt_cnt):
+                raise ValueError("Inconsistent ALT lengths. Got alt_list={}, alt_cnt={}".
+                                 format(alt_list, alt_cnt))
+
+        allele_counter = Counter()
+        for gt, cnt in zip(genotype_list, genotype_cnt):
+            allele_counter[gt.first_allele] += cnt
+            allele_counter[gt.second_allele] += cnt
+
+        for i in range(len(alt_list)):
+            if allele_counter(alt_list[i]) != alt_cnt[i]:
+                raise ValueError("Inconsistent AC value for ALT {}. "
+                                 "Got genotype_list={}, genotype_cnt={}, "
+                                 "alt_list={}, alt_cnt={}".
+                                 format(alt_list[i], genotype_list, genotype_cnt, alt_list, alt_cnt))
+
+        # return nothing if every constraint is met
+        pass
+
+
+class WellderlyTsvReader:
+    @classmethod
+    def generate_document(cls, row: pd.Series, assembly="hg19"):
+        # Read REF and ALT alleles
+        ref = row["REF"]
+
+        alt_list = row["ALT"].split(",")
+        alt_cnt = [int(ac) for ac in row["AC"].split(",")]
+        alt_freq = [float(af) for af in row["AF"].split(",")]
+        if not len(alt_list) == len(alt_cnt) == len(alt_freq):
+            raise ValueError("Inconsistent length between ALT, AC and AF fields. Got row={}".format(row.to_str()))
+
+        # Collect all alleles (REF + ALT)
+        allele_list = alt_list + [ref]
+        allele_freq = alt_freq + [1 - sum(alt_freq)]  # the `AF` column does not have the `REF` allele frequencies
+        allele_json = [{"allele": allele, "freq": freq} for (allele, freq) in zip(allele_list, allele_freq)]
+
+        # Collect all genotypes
+        genotype_cnt = [int(gc) for gc in row["GC"].split(",")]
+        genotype_list = HardyWeinbergHelper.genotype_combinations(ref=ref, alt_list=alt_list)
+        HardyWeinbergHelper.check_count_constraint(genotype_list, genotype_cnt, alt_list, alt_cnt,
+                                                   check_genotype_length=True, check_alt_length=False)
+        genotype_total = sum(genotype_cnt)
+        genotype_freq = [cnt / genotype_total for cnt in genotype_cnt]
+        genotype_json = [{"count": cnt, "freq": freq, 'genotype': str(gt)} for (cnt, freq, gt)
+                         in zip(genotype_cnt, genotype_freq, genotype_list) if cnt > 0]
+
+        # Generate ID and document for each (REF, ALT) pair
+        chrom, pos = row["CHROM:POS"].split(":")
+        for alt in alt_list:
+            hgvsID = MyVariantUtil.format_hgvs(chrom, pos, ref, alt)
+
+            document = {'_id': hgvsID._id, 'chrom': hgvsID.chrom,
+                        'pos': pos, 'ref': ref, 'alt': alt,
+                        assembly: {'start': hgvsID.start, 'end': hgvsID.end},
+                        'vartype': hgvsID.vartype,
+                        'alleles': allele_json,
+                        'genotypes': genotype_json}
+
+            yield document
+
+    @classmethod
+    def load_data(cls, file, assembly="hg19"):
+        # Skip 'AN' column
+        data_types = {"CHROM:POS": str, "REF": str, "ALT": str, "AC": str, "GC": str, "AF": str}
+        df = pd.read_csv(file, sep="\t", usecols=data_types.keys(), dtype=data_types)
+        for _, row in df.iterrows():
+            yield from cls.generate_document(row, assembly)

--- a/src/hub/dataload/sources/wellderly/wellderly_parser.py
+++ b/src/hub/dataload/sources/wellderly/wellderly_parser.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from collections import namedtuple, Counter
+from collections import namedtuple
 from itertools import combinations_with_replacement as cwr
 from utils.hgvs import _normalized_vcf
 

--- a/src/hub/dataload/sources/wellderly/wellderly_parser.py
+++ b/src/hub/dataload/sources/wellderly/wellderly_parser.py
@@ -1,6 +1,78 @@
 import pandas as pd
 from collections import namedtuple, Counter
 from itertools import combinations_with_replacement as cwr
+from utils.hgvs import _normalized_vcf
+
+# (`start`, `end`) can be different from `pos`
+# E.g `chr1:g.10429_10433del` with a genotype `CCCTAA/C`, has pos == 10428, start == 10429 and end == 10433
+HgvsID = namedtuple('HgvsID', ['id', 'chrom', 'start', 'end', 'vartype'])
+
+
+def format_hgvs(chrom, pos, ref, alt):
+    """
+    Get a valid hgvs name from VCF-style "chrom, pos, ref, alt" data.
+
+    This function is adapted from utils.hgvs.format_hgvs.
+
+    TODO: if utils.hgvs.format_hgvs is refactored to return (start, end), delete this and use that function instead
+    See https://github.com/biothings/myvariant.info/issues/111
+    """
+    chrom, pos = str(chrom), int(pos)
+    if chrom.lower().startswith('chr'):
+        # trim off leading "chr" if any
+        chrom = chrom[3:]
+
+    # python integer range is from -2,147,483,648 to 2,147,483,647
+    # The max sequence length is on chr1 (GRCh37.p13), 249,250,621
+    pos = int(pos)
+
+    if len(ref) == len(alt) == 1:
+        # this is a SNP
+        _id = 'chr{0}:g.{1}{2}>{3}'.format(chrom, pos, ref, alt)
+        return HgvsID(id=_id, chrom=chrom, start=pos, end=pos, vartype="snp")
+
+    if len(ref) > 1 and len(alt) == 1:
+        # this is a deletion:
+        if ref[0] == alt:
+            start = pos + 1
+            end = pos + len(ref) - 1
+
+            if start == end:
+                _id = 'chr{0}:g.{1}del'.format(chrom, start)
+            else:
+                _id = 'chr{0}:g.{1}_{2}del'.format(chrom, start, end)
+            return HgvsID(id=_id, chrom=chrom, start=start, end=end, vartype="del")
+        else:
+            start = pos
+            end = start + len(ref) - 1
+
+            _id = 'chr{0}:g.{1}_{2}delins{3}'.format(chrom, start, end, alt)
+            return HgvsID(id=_id, chrom=chrom, start=start, end=end, vartype="delins")
+
+    if len(ref) == 1 and len(alt) > 1:
+        # this is an insertion
+        if alt[0] == ref:
+            start, end = pos, pos + 1
+            ins_seq = alt[1:]
+
+            _id = 'chr{0}:g.{1}_{2}ins{3}'.format(chrom, start, end, ins_seq)
+            return HgvsID(id=_id, chrom=chrom, start=start, end=end, vartype="ins")
+        else:
+            _id = 'chr{0}:g.{1}delins{2}'.format(chrom, pos, alt)
+            return HgvsID(id=_id, chrom=chrom, start=pos, end=pos, vartype="delins")
+
+    if len(ref) > 1 and len(alt) > 1:
+        if ref[0] == alt[0]:
+            # if ref and alt overlap from the left, trim them first
+            _chrom, _pos, _ref, _alt = _normalized_vcf(chrom, pos, ref, alt)
+            return format_hgvs(_chrom, _pos, _ref, _alt)
+        else:
+            start, end = pos, pos + len(ref) - 1
+
+            _id = 'chr{0}:g.{1}_{2}delins{3}'.format(chrom, start, end, alt)
+            return HgvsID(id=_id, chrom=chrom, start=start, end=end, vartype="delins")
+
+    raise ValueError("Cannot convert {} into HGVS id.".format((chrom, pos, ref, alt)))
 
 
 class Genotype:
@@ -11,299 +83,31 @@ class Genotype:
     def __str__(self):
         return "{}/{}".format(self.first_allele, self.second_allele)
 
-# (`start`, `end`) can be different from `pos`
-# E.g `chr1:g.10429_10433del` with a genotype `CCCTAA/C`, has pos == 10428, start == 10429 and end == 10433
-HgvsID = namedtuple('HgvsID', ['_id', 'chrom', 'start', 'end', 'vartype'])
 
-
-class MyVariantUtil:
+def genotype_combinations(ref: str, alt_list: list) -> list:
     """
-    Originally from https://github.com/biothings/biothings_client.py/blob/092ffa1e1e35fbee2c9b7eb5defbee160697e3d8/biothings_client/mixins/variant.py
+    The `GC` column (not VCF-standard) in the Wellderly tsv files represents the count of genotypes in the
+    following patterns.
 
-    Adapted the following two methods to @classmethod's
+    Suppose a, b, c, ..., z represent the allele frequencies.
 
-    Also returned `chrom`, `start`, `end`, `vartype` in `format_hgvs()`
+    For n = 2 alleles, the genotype frequencies are expanded as (a+b)^2 = a^2 + 2ab + b^2.
+    For n = 3 alleles, (a+b+c)^2 = (a+b)^2 + 2(a+b)c + c^2 = a^2 + 2ab + b^2 + 2ac + 2bc + c^2
+    For n = 4 alleles, (a+b+c+d)^2 = (a+b+c)^2 + 2(a+b+c)d + d^2 = ...
+
+    Therefore, the genotype combinations (i.e. the order of the `GC` column) would be
+    0/0, 0/1, 1/1, 0/2, 1/2, 2/2, 0/3, 1/3, 2/3, 3/3, ...
+    ...
+
+    Note that this expanding scheme seems only apply to the Wellderly tsv files.
+
+    For n alleles, there would be {(n+1) choose 2} genotypes regardless of the combination order.
     """
-
-    @classmethod
-    def _normalized_vcf(cls, chrom, pos, ref, alt):
-        """If both ref/alt are > 1 base, and there are overlapping from the left,
-           we need to trim off the overlapping bases.
-           In the case that ref/alt is like this:
-               CTTTT/CT    # with >1 overlapping bases from the left
-           ref/alt should be normalized as TTTT/T, more examples:
-                TC/TG --> C/G
-           and pos should be fixed as well.
-        """
-        for i in range(max(len(ref), len(alt))):
-            _ref = ref[i] if i < len(ref) else None
-            _alt = alt[i] if i < len(alt) else None
-            if _ref is None or _alt is None or _ref != _alt:
-                break
-
-        # _ref/_alt cannot be both None, if so,
-        # ref and alt are exactly the same,
-        # something is wrong with this VCF record
-        # assert not (_ref is None and _alt is None)
-        if _ref is None and _alt is None:
-            raise ValueError('"ref" and "alt" cannot be the same: {}'.format((chrom, pos, ref, alt)))
-
-        _pos = int(pos)
-        if _ref is None or _alt is None:
-            # if either is None, del or ins types
-            _pos = _pos + i - 1
-            _ref = ref[i-1:]
-            _alt = alt[i-1:]
-        else:
-            # both _ref/_alt are not None
-            _pos = _pos + i
-            _ref = ref[i:]
-            _alt = alt[i:]
-
-        return chrom, _pos, _ref, _alt
-
-    @classmethod
-    def format_hgvs(cls, chrom, pos, ref, alt):
-        """get a valid hgvs name from VCF-style "chrom, pos, ref, alt" data.
-        Example:
-            >>> MyVariantUtil.format_hgvs("1", 35366, "C", "T")
-            >>> MyVariantUtil.format_hgvs("2", 17142, "G", "GA")
-            >>> MyVariantUtil.format_hgvs("MT", 8270, "CACCCCCTCT", "C")
-            >>> MyVariantUtil.format_hgvs("X", 107930849, "GGA", "C")
-        """
-        chrom, pos = str(chrom), int(pos)
-        if chrom.lower().startswith('chr'):
-            # trim off leading "chr" if any
-            chrom = chrom[3:]
-
-        # python integer range is from -2,147,483,648 to 2,147,483,647
-        # The max sequence length is on chr1 (GRCh37.p13), 249,250,621
-        pos = int(pos)
-
-        if len(ref) == len(alt) == 1:
-            # this is a SNP
-            _id = 'chr{0}:g.{1}{2}>{3}'.format(chrom, pos, ref, alt)
-            return HgvsID(_id=_id, chrom=chrom, start=pos, end=pos, vartype="snp")
-
-        if len(ref) > 1 and len(alt) == 1:
-            # this is a deletion:
-            if ref[0] == alt:
-                start = pos + 1
-                end = pos + len(ref) - 1
-
-                if start == end:
-                    _id = 'chr{0}:g.{1}del'.format(chrom, start)
-                else:
-                    _id = 'chr{0}:g.{1}_{2}del'.format(chrom, start, end)
-                return HgvsID(_id=_id, chrom=chrom, start=start, end=end, vartype="del")
-            else:
-                start = pos
-                end = start + len(ref) - 1
-
-                _id = 'chr{0}:g.{1}_{2}delins{3}'.format(chrom, start, end, alt)
-                return HgvsID(_id=_id, chrom=chrom, start=start, end=end, vartype="delins")
-
-        if len(ref) == 1 and len(alt) > 1:
-            # this is an insertion
-            if alt[0] == ref:
-                start, end = pos, pos + 1
-                ins_seq = alt[1:]
-
-                _id = 'chr{0}:g.{1}_{2}ins{3}'.format(chrom, start, end, ins_seq)
-                return HgvsID(_id=_id, chrom=chrom, start=start, end=end, vartype="ins")
-            else:
-                _id = 'chr{0}:g.{1}delins{2}'.format(chrom, pos, alt)
-                return HgvsID(_id=_id, chrom=chrom, start=pos, end=pos, vartype="delins")
-
-        if len(ref) > 1 and len(alt) > 1:
-            if ref[0] == alt[0]:
-                # if ref and alt overlap from the left, trim them first
-                _chrom, _pos, _ref, _alt = cls._normalized_vcf(chrom, pos, ref, alt)
-                return cls.format_hgvs(_chrom, _pos, _ref, _alt)
-            else:
-                start, end = pos, pos + len(alt) - 1
-
-                _id = 'chr{0}:g.{1}_{2}delins{3}'.format(chrom, start, end, alt)
-                return HgvsID(_id=_id, chrom=chrom, start=start, end=end, vartype="delins")
-
-        raise ValueError("Cannot convert {} into HGVS id.".format((chrom, pos, ref, alt)))
-
-
-# class HardyWeinbergHelper:
-#     def __init__(self, allele_cnt=10):
-#         if allele_cnt < 1:
-#             raise ValueError("Meaningless count of alleles. Got allele_cnt={}".format(allele_cnt))
-#
-#         self.allele_cnt = allele_cnt
-#         self.hist_of_diploid_genotype_cnt = [self.n_combinations(n, 2, with_replacement=True)
-#                                              for n in range(0, allele_cnt + 1)]
-#
-#     def gc_index(self, nth_alt):
-#         """
-#         The `GC` column (not VCF-standard) in the Wellderly tsv files seems to represent the count of genotypes in the
-#         following patterns.
-#
-#         Suppose a, b, c, ..., z represent the allele frequencies.
-#
-#         For n = 2 alleles, the genotype frequencies are expanded as (a+b)^2 = a^2 + 2ab + b^2. Therefore, e.g. given
-#         REF = A, ALT = T and GC = "1157,23,1", we have number of genotype AA = 1157, AT = 23 and TT = 1. This splitting
-#         pattern must be consistent to the `AC` column (VCF-standard; allele count in genotypes, for each ALT allele,
-#         in the same order as listed). E.g. for the above case, the `AC` field for allele T must be 25
-#         (23 in AT plus 2 in TT).
-#
-#         For n = 3 alleles, expanded as (a+b+c)^2 = (a+b)^2 + 2(a+b)c + c^2 = a^2 + 2ab + b^2 + 2ac + 2bc + c^2
-#         For n = 4 alleles, expanded as (a+b+c+d)^2 = (a+b+c)^2 + 2(a+b+c)d + d^2 = ...
-#         ...
-#
-#         Therefore, the length of a `GC` field is exactly the number of genotypes for that exact row in a Wallderly tsv
-#         file. And no matter how long it is, given a fixed REF allele (whose frequency is 'a')
-#
-#         - For the 1st ALT allele (whose frequency is 'b'), the genotype counts are GC[0], GC[1] and GC[2]
-#         - For the 2nd ALT allele (whose frequency is 'c'), the genotype counts are GC[0], GC[3] and GC[5]
-#         - For the 3rd ALT allele (whose frequency is 'd'), the genotype counts are GC[0], GC[6] and GC[9]
-#         - ...
-#
-#         The index of genotype counts in GC for n-th ALT alleles can be computed from the pre-computed
-#         `self.hist_of_diploid_genotype_cnt`:
-#
-#                              nth_alt =        1, 2, 3,  4,  5,  6,  ...
-#                           allele_cnt =     1, 2, 3, 4,  5,  6,  7,  ...
-#         hist_of_diploid_genotype_cnt = [0, 1, 3, 6, 10, 15, 21, 28, ...]
-#         """
-#
-#         if nth_alt < 1:
-#             raise ValueError("Meaningless order of ALT alleles. Got nth_alt={}".format(nth_alt))
-#
-#         if nth_alt >= self.allele_cnt:
-#             # Dynamically expanding the histogram
-#             updated_allele_cnt = nth_alt + 1
-#             self.hist_of_diploid_genotype_cnt += [self.n_combinations(n, 2, with_replacement=True)
-#                                                   for n in range(self.allele_cnt + 1, updated_allele_cnt + 1)]
-#             self.allele_cnt = updated_allele_cnt
-#
-#         return 0, self.hist_of_diploid_genotype_cnt[nth_alt], self.hist_of_diploid_genotype_cnt[nth_alt+1] - 1
-#
-#     @classmethod
-#     def choose(cls, n, k):
-#         """
-#         A fast way to calculate binomial coefficients.
-#
-#         Originally from https://stackoverflow.com/a/3025547
-#         """
-#         if 0 <= k <= n:
-#             """
-#             Due to the symmetry, (n choose k) == (n choose (n-k)).
-#
-#             Suppose k is small, after the loop:
-#
-#             - numerator = n * (n-1) * ... * (n-(k-1))
-#             - denominator = k * (k-1) * ... * 2 * 1
-#             """
-#             numerator = 1
-#             denominator = 1
-#             for t in range(1, min(k, n - k) + 1):
-#                 numerator *= n
-#                 denominator *= t
-#                 n -= 1
-#             return numerator // denominator
-#         else:
-#             return 0
-#
-#     @classmethod
-#     def n_combinations(cls, n, k, with_replacement=False):
-#         """
-#         Number of combinations when drawing k items out of n.
-#         """
-#         if not with_replacement:
-#             return cls.choose(n, k)
-#         else:
-#             return cls.choose(n + k - 1, k)
-
-class HardyWeinbergHelper:
-    @classmethod
-    def genotype_combinations(cls, ref: str, alt_list: list) -> list:
-        """
-        The `GC` column (not VCF-standard) in the Wellderly tsv files seems to represent the count of genotypes in the
-        following patterns.
-
-        Suppose a, b, c, ..., z represent the allele frequencies.
-
-        For n = 2 alleles, the genotype frequencies are expanded as (a+b)^2 = a^2 + 2ab + b^2. Therefore, e.g. given
-        REF = A, ALT = T and GC = "1157,23,1", we have number of genotype AA = 1157, AT = 23 and TT = 1. This splitting
-        pattern must be consistent to the `AC` column (VCF-standard; allele count in genotypes, for each ALT allele,
-        in the same order as listed). E.g. for the above case, the `AC` field for allele T must be 25
-        (23 in AT plus 2 in TT).
-
-        For n = 3 alleles, expanded as (a+b+c)^2 = (a+b)^2 + 2(a+b)c + c^2 = a^2 + 2ab + b^2 + 2ac + 2bc + c^2
-        For n = 4 alleles, expanded as (a+b+c+d)^2 = (a+b+c)^2 + 2(a+b+c)d + d^2 = ...
-        ...
-
-        Note that this expanding scheme seems only apply to the Wellderly tsv files.
-
-        For n alleles, there would be {(n+1) choose 2} genotypes regardless of the combination order.
-        """
-        # The REF must be the first allele in the list
-        allele_list = [ref] + alt_list
-        genotype_list = [Genotype(first_allele=q, second_allele=p) for (p, q) in cwr(reversed(allele_list), 2)]
-        genotype_list.reverse()
-        return genotype_list
-
-    @classmethod
-    def check_count_constraint(cls, genotype_list: list, genotype_cnt: list, alt_list: list, alt_cnt: list,
-                               check_genotype_length=False, check_alt_length=False):
-        """
-        Check if the `GC` and `AC` columns are consistent with the genotype combination
-
-        `genotype_cnt`, `alt_list` and `alt_cnt` are directly parsed from the `GC`, `ALT` and `AC` columns respectively.
-
-        - GC is not a VCF-standard field
-        - ALT - VCF-standard; alternate base(s): comma-separated list of alternate non-reference alleles.
-        - AC - VCF-standard; allele count in genotypes, for each ALT allele, in the same order as listed
-
-        See https://samtools.github.io/hts-specs/VCFv4.3.pdf for more information about these two fields
-
-        `genotype_list` and `genotype_cnt` should be of the same length;
-        `alt_list` and `alt_cnt` must be of the same length by definition.
-
-        E.g. given REF = C, ALT = [G, T], AC = [3, 2], GC = [78, 3, 0, 0, 0, 1], the genotype combinations must be
-        ['C/C', 'C/G', 'G/G', 'C/T', 'G/T', 'T/T'] and the AC numbers constraint must be met.
-
-        | Genotype | GC | num of 'G' | num of 'T' |
-        |:--------:|:--:|:----------:|:----------:|
-        |    C/C   | 78 |      0     |      0     |
-        |    C/G   |  3 |      3     |      0     |
-        |    G/G   |  0 |      0     |      0     |
-        |    C/T   |  0 |      0     |      0     |
-        |    G/T   |  0 |      0     |      0     |
-        |    T/T   |  1 |      0     |      2     |
-        |    ---   |  - |      -     |      -     |
-        |    AC    |  - |      3     |      2     |
-        """
-
-        if check_genotype_length:
-            if len(genotype_list) != len(genotype_cnt):
-                raise ValueError("Inconsistent genotype lengths. Got genotype_list={}, genotype_cnt={}".
-                                 format(genotype_list, genotype_cnt))
-
-        if check_alt_length:
-            if len(alt_list) != len(alt_cnt):
-                raise ValueError("Inconsistent ALT lengths. Got alt_list={}, alt_cnt={}".
-                                 format(alt_list, alt_cnt))
-
-        allele_counter = Counter()
-        for gt, cnt in zip(genotype_list, genotype_cnt):
-            allele_counter[gt.first_allele] += cnt
-            allele_counter[gt.second_allele] += cnt
-
-        for i in range(len(alt_list)):
-            if allele_counter(alt_list[i]) != alt_cnt[i]:
-                raise ValueError("Inconsistent AC value for ALT {}. "
-                                 "Got genotype_list={}, genotype_cnt={}, "
-                                 "alt_list={}, alt_cnt={}".
-                                 format(alt_list[i], genotype_list, genotype_cnt, alt_list, alt_cnt))
-
-        # return nothing if every constraint is met
-        pass
+    # The REF must be the first allele in the list
+    allele_list = [ref] + alt_list
+    genotype_list = [Genotype(first_allele=q, second_allele=p) for (p, q) in cwr(reversed(allele_list), 2)]
+    genotype_list.reverse()
+    return genotype_list
 
 
 class WellderlyTsvReader:
@@ -325,25 +129,32 @@ class WellderlyTsvReader:
 
         # Collect all genotypes
         genotype_cnt = [int(gc) for gc in row["GC"].split(",")]
-        genotype_list = HardyWeinbergHelper.genotype_combinations(ref=ref, alt_list=alt_list)
-        HardyWeinbergHelper.check_count_constraint(genotype_list, genotype_cnt, alt_list, alt_cnt,
-                                                   check_genotype_length=True, check_alt_length=False)
+        genotype_list = genotype_combinations(ref=ref, alt_list=alt_list)
+
         genotype_total = sum(genotype_cnt)
-        genotype_freq = [cnt / genotype_total for cnt in genotype_cnt]
+        if genotype_total > 0:
+            genotype_freq = [cnt / genotype_total for cnt in genotype_cnt]
+        else:  # In some rare cases, `GC` can be nothing but 0's
+            genotype_freq = [0 for _ in genotype_cnt]
         genotype_json = [{"count": cnt, "freq": freq, 'genotype': str(gt)} for (cnt, freq, gt)
                          in zip(genotype_cnt, genotype_freq, genotype_list) if cnt > 0]
 
         # Generate ID and document for each (REF, ALT) pair
         chrom, pos = row["CHROM:POS"].split(":")
         for alt in alt_list:
-            hgvsID = MyVariantUtil.format_hgvs(chrom, pos, ref, alt)
+            hgvsID = format_hgvs(chrom, pos, ref, alt)
 
-            document = {'_id': hgvsID._id, 'chrom': hgvsID.chrom,
-                        'pos': pos, 'ref': ref, 'alt': alt,
-                        assembly: {'start': hgvsID.start, 'end': hgvsID.end},
-                        'vartype': hgvsID.vartype,
-                        'alleles': allele_json,
-                        'genotypes': genotype_json}
+            document = {
+                '_id': hgvsID.id,
+                'wellderly': {
+                    'chrom': hgvsID.chrom,
+                    'pos': pos, 'ref': ref, 'alt': alt,
+                    assembly: {'start': hgvsID.start, 'end': hgvsID.end},
+                    'vartype': hgvsID.vartype,
+                    'alleles': allele_json,
+                    'genotypes': genotype_json
+                }
+            }
 
             yield document
 

--- a/src/hub/dataload/sources/wellderly/wellderly_upload.py
+++ b/src/hub/dataload/sources/wellderly/wellderly_upload.py
@@ -11,12 +11,12 @@ class WellderlyUploader(ParallelizedSourceUploader, SnpeffPostUpdateUploader):
     name = "wellderly"
 
     __metadata__ = {
-        "mapper" : 'observed',
-        "assembly" : "hg19",
-        "src_meta" : {
-            "url" : "https://genomics.scripps.edu/browser/",
-            "license_url" : "https://genomics.scripps.edu/browser/page-help.html",
-            "license_url_short": "http://bit.ly/2VE6gj7"
+        "mapper": 'observed',
+        "assembly": "hg19",
+        "src_meta": {
+            "url": "https://www.scripps.edu/science-and-medicine/translational-institute/translational-research/genomic-medicine/wellderly/?tab-1-text-content=1",
+            "license_url": "https://redcapstsi.scripps.edu/redcap/surveys/?s=NT4N7A3KJD",
+            "license_url_short": "https://bit.ly/32bNrIu"
         }
     }
 

--- a/src/hub/dataload/sources/wellderly/wellderly_upload.py
+++ b/src/hub/dataload/sources/wellderly/wellderly_upload.py
@@ -14,9 +14,9 @@ class WellderlyUploader(ParallelizedSourceUploader, SnpeffPostUpdateUploader):
         "mapper": 'observed',
         "assembly": "hg19",
         "src_meta": {
-            "url": "https://www.scripps.edu/science-and-medicine/translational-institute/translational-research/genomic-medicine/wellderly/?tab-1-text-content=1",
+            "url": "https://www.scripps.edu/science-and-medicine/translational-institute/translational-research/genomic-medicine/wellderly",
             "license_url": "https://redcapstsi.scripps.edu/redcap/surveys/?s=NT4N7A3KJD",
-            "license_url_short": "https://bit.ly/32bNrIu"
+            "license_url_short": "https://bit.ly/32tpCvP"
         }
     }
 

--- a/src/hub/dataload/sources/wellderly/wellderly_upload.py
+++ b/src/hub/dataload/sources/wellderly/wellderly_upload.py
@@ -25,7 +25,7 @@ class WellderlyUploader(ParallelizedSourceUploader, SnpeffPostUpdateUploader):
         this method will be called by self.update_data() and then generate arguments for self.load.data() method,
         allowing parallelization
         """
-        tsv_filename_pattern = "Wellderly.chr22.g.vcf.gz.tsv"
+        tsv_filename_pattern = "Wellderly.chr*.g.vcf.gz.tsv"
         tsv_file_collection = glob.glob(os.path.join(self.data_folder, tsv_filename_pattern))
 
         assembly = self.__metadata__["assembly"]

--- a/src/hub/dataload/storage.py
+++ b/src/hub/dataload/storage.py
@@ -1,20 +1,98 @@
-from biothings.hub.dataload.storage import BaseStorage, BasicStorage, IgnoreDuplicatedStorage
-from utils.hgvs import encode_long_hgvs_id
+from biothings.hub.dataload.storage import BasicStorage, IgnoreDuplicatedStorage
+from utils.hgvs import DocEncoder
+from config import MAX_REF_ALT_LEN, MAX_ID_LENGTH
+from collections import Mapping
 
 
-class EncodeLongHGVSIDStorage(BaseStorage):
+class MyVariantBasicStorage(BasicStorage):
     """
-    BasicStorage including long HGVC ID encoding
-    """
+    Extended from BasicStorage, providing new implementation of `check_doc_func()` method which encode long HGVS IDs.
+    Long HGVS IDs whose lengths can go beyond the limits of our DB systems (MongoDB especially). This Storage should
+    be used on every plugin where HGVS IDs are the `_id` of the docs.
 
-    def check_doc_func(self, doc):
-        doc = encode_long_hgvs_id(doc)
-        if doc.get("_seqhashed"):
+    See https://github.com/biothings/myvariant.info/issues/91
+    """
+    def encode_long_hgvs_id(self, doc):
+        """
+        Encode long HGVS ID inside the doc
+        """
+        encoded, doc = DocEncoder.encode_long_hgvs_id(doc, max_len=MAX_ID_LENGTH)
+        if encoded:
             # required to query _exists_:_seqhashed
-            doc["_seqhashed"]["_flag"] = True
+            doc[DocEncoder.key_to_seq_map]["_flag"] = True
+            self.logger.info("Encoded a long hgvs id. New id = {}".format(doc["_id"]))
 
         return doc
 
-class MyVariantBasicStorage(EncodeLongHGVSIDStorage, BasicStorage): pass
-class MyVariantIgnoreDuplicatedStorage(EncodeLongHGVSIDStorage, IgnoreDuplicatedStorage): pass
+    def check_doc_func(self, doc):
+        doc = self.encode_long_hgvs_id(doc)
+        return doc
 
+
+class MyVariantTrimmingStorage(MyVariantBasicStorage):
+    """
+    Based on `MyVariantBasicStorage`, this storage class further trims long `ref` and `alt` sequences in every doc.
+    Long `ref` or `alt` sequences as keywords can be rejected by ElasticSearch. Currently this storage is only applied
+    to ClinVar data source.
+
+    See https://github.com/biothings/myvariant.info/issues/110
+    """
+
+    # Known fields in every doc that cannot have "ref" and "alt" sequences for sure
+    # excluded_keys = {"_id", "_seqhashed"}
+    excluded_keys = {DocEncoder.key_to_id, DocEncoder.key_to_seq_map}
+
+    def trim_long_ref_alt_seq(self, doc):
+        """
+        Trim long `ref` and `alt` sequences inside the doc.
+
+        This method holds an assumption that each `doc` object is a dictionary of the following structure:
+
+            {
+                "_id": xxx,
+                "_seqhashed": {...},
+
+                "<source-name>": {
+                    "alt": xxx
+                    "ref": xxx
+                    ...
+                },
+
+                "<additional-key>": {...},
+                "<additional-key>": {...},
+                ...
+            }
+
+        where "_seqhashed" is optional, "<additional-key>" fields are rare (but also looked into for "alt" and "ref"
+        if existing), and "<source-name>" is the field where we anticipate the appearance of the "alt" and "ref"
+        sequences.
+
+        Code is borrowed from `SnpeffPostUpdateUploader.do_snpeff()` method, then modified according to
+        `MyVariantBasicStorage.__encode_long_hgvs_id()` method.
+        """
+        included_keys = [key for key in doc if key not in self.excluded_keys]
+
+        if len(included_keys) > 1:
+            # We assume that if there is only one key left in `included_keys`, it must be the `<source-name>`
+            #   and it's not necessary to check its type if so
+            # If there are more than 1 keys in `included_keys`, we need to further exclude keys not mapped to dict.
+            # The check `isinstance(var, collections.Mapping)` works for `dict()`, `collections.OrderedDict()`, and
+            #   `collections.UserDict()`
+            included_keys = [key for key in included_keys if isinstance(doc[key], Mapping)]
+
+        for key in included_keys:
+            encoded, doc = DocEncoder.encode_long_ref_alt_seq(doc, key, max_len=MAX_REF_ALT_LEN)
+            if encoded:
+                self.logger.info("Trimmed the ref/alt sequences in field {} for a variant with id = {}".
+                                 format(key, doc["_id"]))
+
+        return doc
+
+    def check_doc_func(self, doc):
+        doc = self.encode_long_hgvs_id(doc)
+        doc = self.trim_long_ref_alt_seq(doc)
+        return doc
+
+
+class MyVariantIgnoreDuplicatedStorage(MyVariantBasicStorage, IgnoreDuplicatedStorage):
+    pass

--- a/src/tests/utils/hgvs_test.py
+++ b/src/tests/utils/hgvs_test.py
@@ -1,0 +1,84 @@
+import unittest
+from utils.hgvs import DocEncoder
+
+
+class TestDocEncoder(unittest.TestCase):
+    def setUp(self):
+        self.fake_prefix = "chr1:g.100_103delins"
+        self.fake_seq = "CTAACTAACTAA"
+        self.fake_id = self.fake_prefix + self.fake_seq
+        self.fake_doc = {
+            DocEncoder.key_to_id: self.fake_id
+        }
+
+    def test_encode_long_hgvs_id_with_no_change(self):
+        max_len = len(self.fake_id) + 1  # Ensure it not to be encoded
+        encoded, doc = DocEncoder.encode_long_hgvs_id(self.fake_doc, max_len=max_len)
+
+        self.assertFalse(encoded, "Must have not been encoded")
+        self.assertEqual(self.fake_doc, doc, "No change should be made if not encoded")
+
+    def test_encode_long_hgvs_id_with_assertion_error(self):
+        with self.assertRaises(AssertionError, msg="Expect an AssertionError if '_id' not in doc"):
+            DocEncoder.encode_long_hgvs_id({}, max_len=42)
+
+    def test_encode_long_hgvs_id_without_seq_map_key(self):
+        max_len = len(self.fake_id) // 2  # Ensure it to be encoded
+        encoded, doc = DocEncoder.encode_long_hgvs_id(self.fake_doc, max_len=max_len)
+
+        self.assertTrue(encoded, "Must have been encoded")
+        self.assertTrue(doc[DocEncoder.key_to_id].startswith(self.fake_prefix),
+                        "New ID must starts with the orig prefix")
+        self.assertTrue(DocEncoder.key_to_seq_map in doc, "Must have the seq mapping key")
+        self.assertEqual(len(doc[DocEncoder.key_to_seq_map]), 1, "Seq mapping must have only 1 element here")
+        self.assertEqual(list(doc[DocEncoder.key_to_seq_map].values())[0], self.fake_seq,
+                         "Seq mapping must contain the orig sequence")
+
+    def test_encode_long_hgvs_id_with_seq_map_key(self):
+        self.fake_doc[DocEncoder.key_to_seq_map] = {"foo": "bar"}
+
+        max_len = len(self.fake_id) // 2  # Ensure it to be encoded
+        encoded, doc = DocEncoder.encode_long_hgvs_id(self.fake_doc, max_len=max_len)
+
+        self.assertTrue(encoded, "Must have been encoded")
+        self.assertTrue(doc[DocEncoder.key_to_id].startswith(self.fake_prefix),
+                        "New ID must starts with the orig prefix")
+        self.assertEqual(len(doc[DocEncoder.key_to_seq_map]), 2, "Seq mapping must have only 2 elements here")
+
+        for key, value in doc[DocEncoder.key_to_seq_map].items():
+            if key != "foo":
+                self.assertEqual(value, self.fake_seq, "Seq mapping must contain the orig sequence")
+
+    def test_encode_long_ref_alt_seq_with_assertion_error(self):
+        with self.assertRaises(AssertionError, msg="Expect an AssertionError if key not in doc"):
+            DocEncoder.encode_long_ref_alt_seq({}, key="WhatEver", max_len=42)
+
+    def test_encode_long_ref_alt_seq(self):
+        fake_ref_seq = "CTAACTAACTAACTAACTAACTAACTAACTAACTAACTAACTAACTAACTAACTAACTAACTAACTAACTAACTAACTAACTAACTAACTAACTA"
+        fake_alt_seq = "ACCCCCCCCCCCACCCCCCCCCCCACCCCCCCCCCCACCCCCCCCCCCACCCCCCCCCCCACCCCCCCCCCCACCCCCCCCCCCACCCCCCCCCC"
+        fake_source_key = "wellderly"
+        self.fake_doc[fake_source_key] = {"ref": fake_ref_seq, "alt": fake_alt_seq}
+
+        max_len = max(len(fake_ref_seq), len(fake_alt_seq)) - 20  # Ensure it to be encoded
+        encoded, doc = DocEncoder.encode_long_ref_alt_seq(self.fake_doc, key=fake_source_key, max_len=max_len)
+
+        self.assertTrue(encoded, "Must have been encoded")
+        self.assertTrue(DocEncoder.key_to_seq_map in doc, "Must have the seq mapping key")
+        self.assertEqual(len(doc[DocEncoder.key_to_seq_map]), 2, "Seq mapping must have only 2 element here")
+
+        seqs = doc[DocEncoder.key_to_seq_map].values()
+        self.assertIn(fake_ref_seq, seqs, "ref seq must in the seq mapping")
+        self.assertIn(fake_alt_seq, seqs, "alt seq must in the seq mapping")
+
+    def test_encode_long_ref_alt_seq_without_seq(self):
+        fake_source_key = "wellderly"
+        self.fake_doc[fake_source_key] = {}
+
+        encoded, doc = DocEncoder.encode_long_ref_alt_seq(self.fake_doc, key=fake_source_key, max_len=42)
+
+        self.assertFalse(encoded, "Must have not been encoded")
+        self.assertEqual(self.fake_doc, doc, "No change should be made if not encoded")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR will fix the following issues:

- [Issue#33: update wellderly data](https://github.com/biothings/myvariant.info/issues/33)
- [Issue#91: Include variants with very long hgvs id (>512 chars)](https://github.com/biothings/myvariant.info/issues/91)
- [Issue#110: handle long sequence in ref and alt field](https://github.com/biothings/myvariant.info/issues/110)
- [Issue#115: Typo in load_data function of cadd_parser module](https://github.com/biothings/myvariant.info/issues/115)

## Issue#33

- Added a `ManualDumper` for the lastest Wellderly datasource (received from Chunlei; generated by Dr. Torkamani)
- Added a tsv parser to the Wellderly data
- Modified the original uploader accordingly

## Issue#91

- Applied the correct storage class to `ClingenUploader`, the only uploader possible to cause the problem

P.S. ClinGen data is no longer available, so the fix is **NOT** tested

P.S. The storage class to be applied was originally extended from `EncodeLongHGVSIDStorage`, which disappeared after the refactoring introduced in fixing Issue#110

## Issue#110

- Modified [`src/tests/utils/hgvs.py`](https://github.com/erikyao/myvariant.info/commit/d7ef2c9162ce69d46cdd0266550d67f1e4985460)
    - Folded the `encode_long_hgvs_id()` function into the newly added `DocEncoder` as a class method
    - Added a new `DocEncoder.encode_long_ref_alt_seq()` method to solve the issue
    - Decoupled the above two methods from the existence of the `doc["_seqhashed"]` dictionary
- Modified [`src/hub/dataload/storage.py`](https://github.com/erikyao/myvariant.info/commit/d425007aecc1fe00ccab8a4461925884056bb980)
    - Deleted `EncodeLongHGVSIDStorage`, whose functionality was moved to `MyVariantBasicStorage`
    - Refactored `MyVariantBasicStorage` (using the above `DocEncoder` class) and made it the new base class for other storage classes in MyVariant.info
    - Added a `MyVariantTrimmingStorage` (using the above `DocEncoder` class) especially for ClinVar (the only datasource so far that will have long ref/alt sequences)
    - The difference between `MyVariantBasicStorage` and `MyVariantTrimmingStorage` is that
        - `MyVariantBasicStorage` only encodes long `_id`
        - `MyVariantTrimmingStorage` encodes both long `_id` and long ref/alt sequences

P.S. it is a little difficult to run ClinVar locally (data size, xml parsing, etc.) so `MyVariantTrimmingStorage` is **NOT** tested on ClinVar data (but on Wellderly data)

## Issue#115

- A simple fix of typo. **NOT** tested.