### PR TITLE
Fix to Issue#103

### DIFF
--- a/src/hub/dataindex/indexer.py
+++ b/src/hub/dataindex/indexer.py
@@ -115,12 +115,14 @@ class BaseVariantIndexer(Indexer):
         # update _meta.stats in myvariant_hubdb.src_build
 
         # DO NOT use the following client because the `_build_doc.parse_backend()` in Indexer.__init__() won't work
-        #   for a build_doc. It results in `self.mongo_database_name` equal to "myvariant" and
+        #   for a MyVariant build_doc. It results in `self.mongo_database_name` equal to "myvariant" and
         #   `self.mongo_collection_name` equal to `self.build_doc["_id"]`
         #
         #   mongo_client = MongoClient(**self.mongo_client_args)
         #   mongo_database = mongo_client[self.mongo_database_name]
         #   mongo_collection = mongo_database[self.mongo_collection_name]
+        #
+        # TODO revise if https://github.com/biothings/biothings.api/issues/238 fixed
         src_build_collection = get_src_build()
         self.logger.debug(f"{src_build_collection.database.client}")
         self.logger.debug(f"{src_build_collection.full_name}")

--- a/src/hub/dataindex/indexer.py
+++ b/src/hub/dataindex/indexer.py
@@ -8,7 +8,6 @@ from utils.es import ElasticsearchIndexingService
 
 from elasticsearch import JSONSerializer, SerializationError, Elasticsearch
 from elasticsearch.compat import string_types
-from pymongo.mongo_client import MongoClient
 
 import orjson
 


### PR DESCRIPTION
This is part of the fix to https://github.com/biothings/myvariant.info/issues/103. 

The whole fix involves two parts:

- **Biothings.api Implementation:** When generating a release note between two builds, $x$ and $y$, the Publisher in Biothings.api codebase will read 3 major pieces of information for each build, i.e. _**build stats**_, _**datasource stats**_, and _**mappings**_. However, if a build $x$ has a `cold_collection`, which corresponds to another build $x'$, the Publisher should read the combined stats/mappings of $x$ and $x'$.
    1. For _**build stats**_, the Publisher will read the combined stats in $x$, no need to read $x'$.
    1. For _**datasource stats**_, the Publisher will read the datasource fields in both $x$ and $x'$
    1. For _**mappings**_, the Publisher will read the mapping fields in both $x$ and $x'$
Note that **Biothings.api Implementatio** should work **compatibly** even if build $x$ is a vanilla  without a `cold_collection`.
- **MyVariant.info Implementation:** The MyVariant indexer should update the _**build stats**_ of $x$ (in **post-index** steps). Previously we only updated the build stats to ES mapping `meta` field. Such build stats should also be written into MongoDB.

This PR is the **MyVariant.info Implementation**, which enables the **Biothings.api Implementation** workflow i.

P.S. The **Biothings.api Implementation** is proposed by https://github.com/biothings/biothings.api/pull/240