### PR TITLE
Migrate ClinVar to RCV format; rebuild UniProt; harden dbSNP/dbNSFP dumps

### DIFF
--- a/src/hub/dataload/sources/clinvar/clinvar_dump.py
+++ b/src/hub/dataload/sources/clinvar/clinvar_dump.py
@@ -17,14 +17,14 @@ class ClinvarDumper(FTPDumper):
     SRC_NAME = "clinvar"
     SRC_ROOT_FOLDER = os.path.join(DATA_ARCHIVE_ROOT, SRC_NAME)
     FTP_HOST = 'ftp.ncbi.nlm.nih.gov'
-    CWD_DIR = '/pub/clinvar/xml/RCV_xml_old_format'
+    CWD_DIR = '/pub/clinvar/xml/RCV_release'
 
     SCHEDULE = "0 9 * * *"
 
     def get_newest_info(self):
         releases = self.client.nlst()
         # get rid of readme files
-        releases = [x for x in releases if x.startswith('ClinVarFullRelease') and x.endswith('gz')]
+        releases = [x for x in releases if x.startswith('ClinVarRCVRelease') and x.endswith('gz')]
         # sort items based on date
         releases = sorted(releases)
         # get the last item in the list, which is the latest version
@@ -52,9 +52,9 @@ class ClinvarDumper(FTPDumper):
             # register new release (will be stored in backend)
             self.to_dump.append({"remote": self.newest_file, "local": new_localfile})
             # schema
-            xsd = "clinvar_public.xsd"
+            xsd = "ClinVar_RCV.xsd"
             localxsdfile = os.path.join(self.new_data_folder, xsd)
-            self.to_dump.append({"remote": "../../xsd_public/RCV_xsd_old_format/%s" % xsd, "local": localxsdfile})
+            self.to_dump.append({"remote": "../../xsd_public/RCV/%s" % xsd, "local": localxsdfile})
 
     def post_dump(self, *args, **kwargs):
         generate_clinvar_lib(self.new_data_folder)
@@ -66,12 +66,12 @@ def generate_clinvar_lib(data_folder):
     try:
         os.chdir(data_folder)
         logging.info("Generate XM parser")
-        # ret = os.system('''generateDS.py -f -o "clinvar_tmp.py" -s "clinvarsubs.py" clinvar_public.xsd''')
+        # ret = os.system('''generateDS.py -f -o "clinvar_tmp.py" -s "clinvarsubs.py" ClinVar_RCV.xsd''')
         cmd = shutil.which('generateDS.py')
         if not cmd:
             raise OSError('"generateDS.py" is not found in the PATH!')
         # logging.info("CMD: %s; PATH: %s", cmd, os.environ.get("PATH"))
-        cmd += " -f -o clinvar_tmp.py -s clinvarsubs.py clinvar_public.xsd"
+        cmd += " -f -o clinvar_tmp.py -s clinvarsubs.py ClinVar_RCV.xsd"
         # logging.info("CMD: %s", cmd)
         ret = subprocess.call(cmd, shell=True)
         if ret != 0:

--- a/src/hub/dataload/sources/clinvar/clinvar_xml_parser.py
+++ b/src/hub/dataload/sources/clinvar/clinvar_xml_parser.py
@@ -6,13 +6,13 @@ Two major parsing functions in this script are:
 
 `clinvar_doc_feeder()` is responsible for the following jobs:
 
-    1. Receive a ClinVarFullRelease_*.xml.gz file, and split the xml file into `<ClinVarSet>...</ClinVarSet>` blocks
+    1. Receive a ClinVarRCVRelease_*.xml.gz file, and split the xml file into `<ClinVarSet>...</ClinVarSet>` blocks
     2. Parse each `<ClinVarSet>...</ClinVarSet>` block into an `PublicSetType` object, which is defined in the
         dynamically imported `clinvarlib`
     3. Convert each `PublicSetType` object into a clinvar document
 
 Note that The `PublicSetType` class is defined to map the block structure of `<ClinVarSet>`, which can be inspected
-through its XSD, https://ftp.ncbi.nlm.nih.gov/pub/clinvar/clinvar_public.xsd.
+through its XSD, https://ftp.ncbi.nlm.nih.gov/pub/clinvar/xsd_public/RCV/ClinVar_RCV.xsd.
 
 `merge_rcv_accession()` is responsible for only one job:
 
@@ -31,7 +31,7 @@ biothings.config_for_app(config)
 
 from biothings.utils.dataload import unlist, dict_sweep, value_convert_to_number, rec_handler
 
-GLOB_PATTERN = "ClinVarFullRelease_*.xml.gz"
+GLOB_PATTERN = "ClinVarRCVRelease_*.xml.gz"
 clinvarlib = None
 
 
@@ -288,6 +288,58 @@ def _map_measure_to_json(measure_obj, hg19=True):
         return one_snp_json
 
 
+def _extract_classification(classifications):
+    """
+    Extract (clinical_significance, review_status, last_evaluated) out of a
+    `clinvarlib.ClassificationType` object (the `<Classifications>` block of a
+    `<ReferenceClinVarAssertion>`).
+
+    Since ClinVar's 2025-08-07 XML format update, the single `<ClinicalSignificance>`
+    element was replaced by `<Classifications>`, which bundles separate, mutually
+    exclusive sub-elements: `GermlineClassification`, `OncogenicityClassification`,
+    `SomaticClinicalImpact` (a list, unlike the other two) and `NoClassification`.
+    We prefer `GermlineClassification` since it matches the semantics of the old
+    `ClinicalSignificance` element, falling back to the other classification types
+    only when germline classification isn't available.
+    """
+    if classifications is None:
+        return None, None, None
+
+    germline = classifications.GermlineClassification
+    if germline is not None:
+        description = germline.Description
+        return (
+            description.valueOf_ if description is not None else None,
+            germline.ReviewStatus,
+            description.DateLastEvaluated if description is not None else None,
+        )
+
+    oncogenicity = classifications.OncogenicityClassification
+    if oncogenicity is not None:
+        description = oncogenicity.Description
+        return (
+            description.valueOf_ if description is not None else None,
+            oncogenicity.ReviewStatus,
+            description.DateLastEvaluated if description is not None else None,
+        )
+
+    somatic = classifications.SomaticClinicalImpact
+    if somatic is not None and somatic.Description:
+        description = somatic.Description[0]
+        return description.valueOf_, somatic.ReviewStatus, description.DateLastEvaluated
+
+    no_classification = classifications.NoClassification
+    if no_classification is not None:
+        description = no_classification.Description
+        return (
+            description.valueOf_ if description is not None else None,
+            no_classification.ReviewStatus,
+            None,
+        )
+
+    return None, None, None
+
+
 def _map_public_set_to_json(public_set_obj, hg19: bool):
     """
     Convert a `clinvarlib.PublicSetType` object into a json document.
@@ -304,23 +356,11 @@ def _map_public_set_to_json(public_set_obj, hg19: bool):
           </ReferenceClinVarAssertion>
         </ClinVarSet>
     """
-    try:
-        clinical_significance = public_set_obj.ReferenceClinVarAssertion.ClinicalSignificance.Description
-    except:
-        clinical_significance = None
+    clinical_significance, review_status, last_evaluated = _extract_classification(
+        public_set_obj.ReferenceClinVarAssertion.Classifications)
 
     rcv_accession = public_set_obj.ReferenceClinVarAssertion.ClinVarAccession.Acc
 
-    try:
-        review_status = public_set_obj.ReferenceClinVarAssertion.ClinicalSignificance.ReviewStatus
-    except:
-        review_status = None
-
-    try:
-        last_evaluated = public_set_obj.ReferenceClinVarAssertion.ClinicalSignificance.DateLastEvaluated
-    except:
-        last_evaluated = None
-    
     number_submitters = len(public_set_obj.ClinVarAssertion)
 
     # some items in clinvar_xml doesn't have origin information
@@ -421,7 +461,7 @@ def clinvar_doc_feeder(input_file, hg19: bool):
     """
 
     """
-    A ClinVarFullRelease_*.xml.gz file has the following structure:
+    A ClinVarRCVRelease_*.xml.gz file has the following structure:
     
         <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
         <ReleaseSet Dated="2021-06-26" ...>

--- a/src/hub/dataload/sources/clinvar/clinvar_xml_parser.py
+++ b/src/hub/dataload/sources/clinvar/clinvar_xml_parser.py
@@ -455,9 +455,14 @@ def clinvar_doc_feeder(input_file, hg19: bool):
         try:
             # Parse each `<ClinVarSet>` block into a `clinvarlib.PublicSetType` object
             public_set_obj = clinvarlib.parseString(clinvar_set_block, silence=1)
-        except:
+        except Exception as e:
             logging.debug(clinvar_set_block)
-            raise
+            # Some lxml exceptions (e.g. XMLSyntaxError) carry an unpicklable
+            # 'error_log' (lxml.etree._ListErrorLog) attribute. Since this
+            # generator runs in a worker process, letting that exception
+            # propagate as-is breaks pickling it back to the hub process and
+            # masks the real error. Re-raise as a plain, picklable exception.
+            raise RuntimeError("Failed to parse ClinVarSet block: %s" % e) from None
 
         # Convert each `clinvarlib.PublicSetType` object into a json document
         for doc in _map_public_set_to_json(public_set_obj, hg19):

--- a/src/hub/dataload/sources/dbnsfp/README.md
+++ b/src/hub/dataload/sources/dbnsfp/README.md
@@ -7,8 +7,10 @@ release zip) into `dbnsfp` documents for both the `hg19` and `hg38` assemblies.
 The `dbNSFP_gene` file is never parsed - only the variant-level scores/annotations
 are indexed.
 
-There are two parser flavors per dbNSFP version, e.g. `dbnsfp_parser_531a_v1.py` /
-`dbnsfp_parser_531a_v2.py`:
+There are two parser flavors per dbNSFP version, e.g. `dbnsfp_parser_54a_v1.py` /
+`dbnsfp_parser_54a_v2.py`. `dbnsfp_upload.py` currently registers 54a (the
+newest version implemented here) - other version-suffixed parser/mapping files
+in this directory are kept for reference but are not wired into any uploader.
 
 - **v1**: per-transcript annotations (REVEL, SIFT, etc.) are flattened onto the
   document; when a variant has multiple transcript rows, only the first row's
@@ -31,8 +33,8 @@ series, getting the data requires a **manual, human-gated request**:
    and access code. This emails back release-specific download links, e.g.:
 
    ```text
-   https://dist.genos.us/academic/<token>/dbNSFP5.3.1a.zip
-   https://dist.genos.us/academic/<token>/dbNSFP5.3.1a.zip.md5
+   https://dist.genos.us/academic/<token>/dbNSFP5.4a.zip
+   https://dist.genos.us/academic/<token>/dbNSFP5.4a.zip.md5
    ```
 
    (There are also separate BGZF-format links for VEP/SnpSift and a
@@ -75,7 +77,7 @@ and the release is the academic ("a") branch.
   first row's. This is the root cause of
   [issue #179](https://github.com/biothings/myvariant.info/issues/179) and is
   unresolved in v1 by design - v2 exists specifically to fix it. See
-  `src/tests/data/test_dbnsfp_parser.py` and `test_dbnsfp_parser_531a.py`.
+  `src/tests/data/test_dbnsfp_parser.py` and `test_dbnsfp_parser_54a.py`.
 - **hs1 (T2T-CHM13 v2.0) coordinates are captured but not queryable as their own
   assembly.** `hs1_pos(1-based)` is stored as an auxiliary `hs1: {start, end}`
   field on both the hg19 and hg38 documents (mirroring how `hg18_pos(1-based)`

--- a/src/hub/dataload/sources/dbnsfp/dbnsfp_mapping_54a_v1.py
+++ b/src/hub/dataload/sources/dbnsfp/dbnsfp_mapping_54a_v1.py
@@ -1,0 +1,674 @@
+start_pos_field = {"start": {"type": "integer"}}
+end_pos_field = {"end": {"type": "integer"}}
+
+score_field = {"score": {"type": "float"}}
+converted_rankscore_field = {"converted_rankscore": {"type": "float"}}
+rankscore_field = {"rankscore": {"type": "float"}}
+keyword_value_field = {
+    "type": "keyword",
+    "normalizer": "keyword_lowercase_normalizer"
+}
+pred_field = {"pred": keyword_value_field}
+
+allele_count_field = {"ac": {"type": "integer"}}
+allele_num_field = {"an": {"type": "integer"}}
+allele_freq_field = {"af": {"type": "float"}}
+
+mapping = {
+    "dbnsfp": {
+        "properties": {
+            "rsid": keyword_value_field,
+            "chrom": keyword_value_field,
+            "hg19": {
+                "properties": {
+                    **start_pos_field,
+                    **end_pos_field
+                }
+            },
+            "hg18": {
+                "properties": {
+                    **start_pos_field,
+                    **end_pos_field
+                }
+            },
+            "hg38": {
+                "properties": {
+                    **start_pos_field,
+                    **end_pos_field
+                }
+            },
+            "hs1": {  # new in dbNSFP 5.3.1 (T2T-CHM13 v2.0 coordinates)
+                "properties": {
+                    **start_pos_field,
+                    **end_pos_field
+                }
+            },
+            "ref": keyword_value_field,
+            "alt": keyword_value_field,
+            "aa": {
+                "properties": {
+                    "ref": keyword_value_field,
+                    "alt": keyword_value_field,
+                    "pos": keyword_value_field,
+                    "refcodon": keyword_value_field,
+                    "codonpos": keyword_value_field,
+                    "codon_degeneracy": keyword_value_field
+                }
+            },
+            "genename": keyword_value_field,
+            "ensembl": {
+                "properties": {
+                    "geneid": keyword_value_field,
+                    "transcriptid": keyword_value_field,
+                    "proteinid": keyword_value_field
+                }
+            },
+            "uniprot": {
+                "properties": {
+                    "acc": keyword_value_field,
+                    "entry": keyword_value_field
+                }
+            },
+            "hgvsc": keyword_value_field,
+            "hgvsp": keyword_value_field,
+            "appris": keyword_value_field,
+            "gencode_basic": keyword_value_field,
+            "tsl": {
+                "type": "integer"
+            },
+            "ensembl_canonical": keyword_value_field,  # renamed from vep_canonical (source column VEP_canonical -> Ensembl_canonical) in dbNSFP 5.4
+            "mane": keyword_value_field,  # new in dbNSFP 5.0
+            "cds_strand": keyword_value_field,
+            "ancestral_allele": keyword_value_field,
+            "altai_neandertal": keyword_value_field,
+            "denisova": keyword_value_field,
+            "vindijia_neandertal": keyword_value_field,
+            "chagyrskaya_neandertal": keyword_value_field,
+            "clinvar": {
+                "properties": {
+                    "clinvar_id": keyword_value_field,
+                    "clnsig": keyword_value_field,
+                    "trait": keyword_value_field,
+                    "review": keyword_value_field,
+                    "hgvs": keyword_value_field,
+                    "var_source": keyword_value_field,
+                    "medgen": keyword_value_field,
+                    "omim": keyword_value_field,
+                    "orphanet": keyword_value_field
+                }
+            },
+            "interpro": {
+                "properties": {
+                    "domain": {
+                        "type": "text"
+                    }
+                }
+            },
+            "sift": {
+                "properties": {
+                    **score_field,
+                    **converted_rankscore_field,
+                    **pred_field
+                }
+            },
+            "sift4g": {
+                "properties": {
+                    **score_field,
+                    **converted_rankscore_field,
+                    **pred_field
+                }
+            },
+            "polyphen2": {
+                "properties": {
+                    "hdiv": {
+                        "properties": {
+                            **score_field,
+                            **rankscore_field,
+                            **pred_field
+                        }
+                    },
+                    "hvar": {
+                        "properties": {
+                            **score_field,
+                            **rankscore_field,
+                            **pred_field
+                        }
+                    }
+                }
+            },
+            # LRT retired by dbNSFP 5.0
+            "mutationtaster": {
+                # MutationTaster2021 (dbNSFP 5.0): MutationTaster_AAE retired, trees_benign/trees_deleterious added.
+                # v1 has no per-transcript merge step for this field (unlike v2's "analysis" list), so it stays flat.
+                "properties": {
+                    **score_field,
+                    **rankscore_field,
+                    **pred_field,
+                    "model": keyword_value_field,
+                    "trees_benign": {
+                        "type": "integer"
+                    },
+                    "trees_deleterious": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "mutationassessor": {
+                "properties": {
+                    **score_field,
+                    **rankscore_field,
+                    **pred_field,
+                }
+            },
+            # FATHMM retired by dbNSFP 5.0
+            "provean": {
+                "properties": {
+                    **score_field,
+                    **converted_rankscore_field,
+                    **pred_field
+                }
+            },
+            "vest4": {
+                "properties": {
+                    **score_field,
+                    **rankscore_field
+                }
+            },
+            "metasvm": {
+                "properties": {
+                    **score_field,
+                    **rankscore_field,
+                    **pred_field
+                }
+            },
+            "metalr": {
+                "properties": {
+                    **score_field,
+                    **rankscore_field,
+                    **pred_field
+                }
+            },
+            "reliability_index": {
+                "type": "integer"
+            },
+            "metarnn": {
+                "properties": {
+                    **score_field,
+                    **rankscore_field,
+                    **pred_field
+                }
+            },
+            "m-cap": {
+                "properties": {
+                    **score_field,
+                    **rankscore_field,
+                    **pred_field
+                }
+            },
+            "revel": {
+                "properties": {
+                    **score_field,
+                    **rankscore_field
+                }
+            },
+            "mutpred2": {  # replaces MutPred (v1) in dbNSFP 5.2
+                "properties": {
+                    **score_field,
+                    **rankscore_field,
+                    **pred_field,
+                    "mechanisms": {
+                        "properties": {
+                            "p_val": {
+                                "type": "float"
+                            },
+                            "mechanism": {
+                                "type": "text"
+                            }
+                        }
+                    }
+                }
+            },
+            "mvp": {
+                "properties": {
+                    **score_field,
+                    **rankscore_field
+                }
+            },
+            "gmvp": {
+                "properties": {
+                    **score_field,
+                    **rankscore_field
+                }
+            },
+            "misfit": {  # new in dbNSFP 5.3
+                "properties": {
+                    "d": {
+                        "properties": {
+                            **score_field,
+                            **rankscore_field,
+                            "pred_lenient": keyword_value_field,
+                            "pred_stringent": keyword_value_field
+                        }
+                    },
+                    "s": {
+                        "properties": {
+                            **score_field,
+                            **rankscore_field
+                        }
+                    }
+                }
+            },
+            "mpc": {
+                "properties": {
+                    **score_field,
+                    **rankscore_field
+                }
+            },
+            "primateai": {
+                "properties": {
+                    **score_field,
+                    **rankscore_field,
+                    **pred_field
+                }
+            },
+            "deogen2": {
+                "properties": {
+                    **score_field,
+                    **rankscore_field,
+                    **pred_field
+                }
+            },
+            "bayesdel": {
+                "properties": {
+                    "add_af": {
+                        "properties": {
+                            **score_field,
+                            **rankscore_field,
+                            **pred_field
+                        }
+                    },
+                    "no_af": {
+                        "properties": {
+                            **score_field,
+                            **rankscore_field,
+                            **pred_field
+                        }
+                    }
+                }
+            },
+            "clinpred": {
+                "properties": {
+                    **score_field,
+                    **rankscore_field,
+                    **pred_field
+                }
+            },
+            "list-s2": {
+                "properties": {
+                    **score_field,
+                    **rankscore_field,
+                    **pred_field
+                }
+            },
+            "varity": {
+                "properties": {
+                    "r": {
+                        "properties": {
+                            **score_field,
+                            **rankscore_field
+                        }
+                    },
+                    "er": {
+                        "properties": {
+                            **score_field,
+                            **rankscore_field
+                        }
+                    },
+                    "r_loo": {
+                        "properties": {
+                            **score_field,
+                            **rankscore_field
+                        }
+                    },
+                    "er_loo": {
+                        "properties": {
+                            **score_field,
+                            **rankscore_field
+                        }
+                    }
+                }
+            },
+            "esm1b": {
+                "properties": {
+                    **score_field,
+                    **converted_rankscore_field,  # renamed from ESM1b_rankscore in dbNSFP 5.2
+                    **pred_field
+                }
+            },
+            # EVE retired by dbNSFP 5.0
+            "alphamissense": {
+                "properties": {
+                    **score_field,
+                    **rankscore_field,
+                    **pred_field
+                }
+            },
+            "phactboost": {
+                "properties": {
+                    **score_field,
+                    **rankscore_field
+                }
+            },
+            "mutformer": {
+                "properties": {
+                    **score_field,
+                    **rankscore_field
+                }
+            },
+            "mutscore": {  # new in dbNSFP 4.9a
+                "properties": {
+                    **score_field,
+                    **rankscore_field
+                }
+            },
+            "popeve": {  # new in dbNSFP 5.3.1
+                "properties": {
+                    **score_field,
+                    **pred_field,
+                    **converted_rankscore_field
+                }
+            },
+            "aloft": {
+                "properties": {
+                    "fraction_transcripts_affected": keyword_value_field,
+                    "prob_tolerant": keyword_value_field,
+                    "prob_recessive": keyword_value_field,
+                    "prob_dominant": keyword_value_field,
+                    "pred": keyword_value_field,
+                    "confidence": {
+                        "type": "text"
+                    }
+                }
+            },
+            "cadd": {
+                # Only for "hg38"
+                # No CADD fields will be included for "hg19"
+                "properties": {
+                    "raw_score": {
+                        "type": "float"
+                    },
+                    "raw_rankscore": {
+                        "type": "float"
+                    },
+                    "phred": {
+                        "type": "float"  # CADD phred-like scores, not as other predications of string type
+                    }
+                }
+            },
+            "dann": {
+                "properties": {
+                    **score_field,
+                    **rankscore_field
+                }
+            },
+            # fathmm-MKL retired by dbNSFP 5.0
+            "fathmm-xf": {
+                "properties": {
+                    "coding_score": {
+                        "type": "float"
+                    },
+                    "coding_rankscore": {
+                        "type": "float"
+                    },
+                    "coding_pred": keyword_value_field
+                }
+            },
+            "eigen": {
+                "properties": {
+                    "raw_coding": {
+                        "type": "float"
+                    },
+                    "raw_coding_rankscore": {
+                        "type": "float"
+                    },
+                    "phred_coding": {
+                        "type": "float"
+                    }
+                }
+            },
+            "eigen-pc": {
+                "properties": {
+                    "raw_coding": {
+                        "type": "float"
+                    },
+                    "raw_coding_rankscore": {
+                        "type": "float"
+                    },
+                    "phred_coding": {
+                        "type": "float"
+                    },
+                }
+            },
+            "gpn_msa": {  # new in dbNSFP 5.4
+                "properties": {
+                    **score_field,
+                    **converted_rankscore_field,
+                    **pred_field
+                }
+            },
+            # GenoCanyon retired by dbNSFP 5.0
+            # fitCons (integrated, GM12878, H1-hESC, HUVEC) retired by dbNSFP 5.0
+            # LINSIGHT retired by dbNSFP 5.0
+            "gerp++": {
+                "properties": {
+                    "nr": {
+                        "type": "float"
+                    },
+                    "rs": {
+                        "type": "float"
+                    },
+                    "rs_rankscore": {
+                        "type": "float"
+                    }
+                }
+            },
+            "gerp": {
+                "properties": {
+                    "92_mammals": {  # renamed from 91_mammals in dbNSFP 5.3
+                        "properties": {
+                            **score_field,
+                            **rankscore_field
+                        }
+                    }
+                }
+            },
+            "phylop": {
+                "properties": {
+                    "100way_vertebrate": {
+                        "properties": {
+                            **score_field,
+                            **rankscore_field
+                        }
+                    },
+                    "470way_mammalian": {
+                        "properties": {
+                            **score_field,
+                            **rankscore_field
+                        }
+                    },
+                    "17way_primate": {
+                        "properties": {
+                            **score_field,
+                            **rankscore_field
+                        }
+                    }
+                }
+            },
+            "phastcons": {
+                "properties": {
+                    "100way_vertebrate": {
+                        "properties": {
+                            **score_field,
+                            **rankscore_field
+                        }
+                    },
+                    "470way_mammalian": {
+                        "properties": {
+                            **score_field,
+                            **rankscore_field
+                        }
+                    },
+                    "17way_primate": {
+                        "properties": {
+                            **score_field,
+                            **rankscore_field
+                        }
+                    }
+                }
+            },
+            # SiPhy retired by dbNSFP 5.0
+            "bstatistic": {
+                "properties": {
+                    **score_field,
+                    **converted_rankscore_field
+                }
+            },
+            "1000gp3": {
+                "properties": {
+                    **allele_count_field,
+                    **allele_freq_field,
+                    "afr": {
+                        "properties": {
+                            **allele_count_field,
+                            **allele_freq_field
+                        }
+                    },
+                    "eur": {
+                        "properties": {
+                            **allele_count_field,
+                            **allele_freq_field
+                        }
+                    },
+                    "amr": {
+                        "properties": {
+                            **allele_count_field,
+                            **allele_freq_field
+                        }
+                    },
+                    "eas": {
+                        "properties": {
+                            **allele_count_field,
+                            **allele_freq_field
+                        }
+                    },
+                    "sas": {
+                        "properties": {
+                            **allele_count_field,
+                            **allele_freq_field
+                        }
+                    }
+                }
+            },
+            # TWINSUK, ALSPAC, UK10K, ESP6500, ExAC, ExAC_nonTCGA, ExAC_nonpsych retired by dbNSFP 5.0
+            # TOPMed freeze8, gnomAD2.1.1 exomes controls/non_neuro/non_cancer, gnomAD4.1 joint, All of Us, and
+            # RegeneronME are in the file but not parsed here (counted in VALID_COLUMN_NO only), consistent with
+            # gnomAD never being expanded into individual columns in earlier versions either (e.g. 4.8a)
+            "alfa": {
+                "properties": {
+                    "european": {
+                        "properties": {
+                            **allele_count_field,
+                            **allele_num_field,
+                            **allele_freq_field
+                        }
+                    },
+                    "african_others": {
+                        "properties": {
+                            **allele_count_field,
+                            **allele_num_field,
+                            **allele_freq_field
+                        }
+                    },
+                    "east_asian": {
+                        "properties": {
+                            **allele_count_field,
+                            **allele_num_field,
+                            **allele_freq_field
+                        }
+                    },
+                    "african_american": {
+                        "properties": {
+                            **allele_count_field,
+                            **allele_num_field,
+                            **allele_freq_field
+                        }
+                    },
+                    "latin_american_1": {
+                        "properties": {
+                            **allele_count_field,
+                            **allele_num_field,
+                            **allele_freq_field
+                        }
+                    },
+                    "latin_american_2": {
+                        "properties": {
+                            **allele_count_field,
+                            **allele_num_field,
+                            **allele_freq_field
+                        }
+                    },
+                    "other_asian": {
+                        "properties": {
+                            **allele_count_field,
+                            **allele_num_field,
+                            **allele_freq_field
+                        }
+                    },
+                    "south_asian": {
+                        "properties": {
+                            **allele_count_field,
+                            **allele_num_field,
+                            **allele_freq_field
+                        }
+                    },
+                    "other": {
+                        "properties": {
+                            **allele_count_field,
+                            **allele_num_field,
+                            **allele_freq_field
+                        }
+                    },
+                    "african": {
+                        "properties": {
+                            **allele_count_field,
+                            **allele_num_field,
+                            **allele_freq_field
+                        }
+                    },
+                    "asian": {
+                        "properties": {
+                            **allele_count_field,
+                            **allele_num_field,
+                            **allele_freq_field
+                        }
+                    },
+                    "total": {
+                        "properties": {
+                            **allele_count_field,
+                            **allele_num_field,
+                            **allele_freq_field
+                        }
+                    },
+                }
+            },
+            "dbnsfp_popmax": {  # new in dbNSFP 5.1
+                "properties": {
+                    **allele_freq_field,
+                    **allele_count_field,
+                    "pop": keyword_value_field
+                }
+            }
+            # GTEx, eQTLGen, and Geuvadis eQTL columns retired by dbNSFP 5.0
+        }
+    }
+}

--- a/src/hub/dataload/sources/dbnsfp/dbnsfp_mapping_54a_v2.py
+++ b/src/hub/dataload/sources/dbnsfp/dbnsfp_mapping_54a_v2.py
@@ -1,0 +1,744 @@
+start_pos_field = {"start": {"type": "integer"}}
+end_pos_field = {"end": {"type": "integer"}}
+
+score_field = {"score": {"type": "float"}}
+converted_rankscore_field = {"converted_rankscore": {"type": "float"}}
+rankscore_field = {"rankscore": {"type": "float"}}
+keyword_value_field = {
+    "type": "keyword",
+    "normalizer": "keyword_lowercase_normalizer"
+}
+pred_field = {"pred": keyword_value_field}
+
+allele_count_field = {"ac": {"type": "integer"}}
+allele_num_field = {"an": {"type": "integer"}}
+allele_freq_field = {"af": {"type": "float"}}
+
+mapping = {
+    "dbnsfp": {
+        "properties": {
+            "rsid": keyword_value_field,
+            "chrom": keyword_value_field,
+            "hg19": {
+                "properties": {
+                    **start_pos_field,
+                    **end_pos_field
+                }
+            },
+            "hg18": {
+                "properties": {
+                    **start_pos_field,
+                    **end_pos_field
+                }
+            },
+            "hg38": {
+                "properties": {
+                    **start_pos_field,
+                    **end_pos_field
+                }
+            },
+            "hs1": {  # new in dbNSFP 5.3.1 (T2T-CHM13 v2.0 coordinates)
+                "properties": {
+                    **start_pos_field,
+                    **end_pos_field
+                }
+            },
+            "ref": keyword_value_field,
+            "alt": keyword_value_field,
+            "aa": {
+                "properties": {
+                    "ref": keyword_value_field,
+                    "alt": keyword_value_field,
+                }
+            },
+            "protein": {
+                "properties": {
+                    "aa": {
+                        "properties": {
+                            "pos": keyword_value_field,
+                            "refcodon": keyword_value_field,
+                            "codonpos": keyword_value_field,
+                            "codon_degeneracy": keyword_value_field,
+                        }
+                    },
+                    "genename": keyword_value_field,
+                    "geneid": keyword_value_field,
+                    "transcriptid": keyword_value_field,
+                    "proteinid": keyword_value_field,
+                    "uniprot": {
+                        "properties": {
+                            "acc": keyword_value_field,
+                            "entry": keyword_value_field
+                        }
+                    },
+                    "hgvsc": {
+                        # HGVSc_ANNOVAR retired by dbNSFP 5.0; only snpEff and VEP sources remain
+                        "properties": {
+                            "snpeff": keyword_value_field,
+                            "vep": keyword_value_field
+                        }
+                    },
+                    "hgvsp": {
+                        # HGVSp_ANNOVAR retired by dbNSFP 5.0; only snpEff and VEP sources remain
+                        "properties": {
+                            "snpeff": keyword_value_field,
+                            "vep": keyword_value_field
+                        }
+                    },
+                    "appris": keyword_value_field,
+                    "gencode_basic": keyword_value_field,
+                    "tsl": {
+                        "type": "integer"
+                    },
+                    "ensembl_canonical": keyword_value_field,  # renamed from vep_canonical in dbNSFP 5.4
+                    "mane": keyword_value_field,  # new in dbNSFP 5.0
+                    "sift": {
+                        "properties": {
+                            **score_field,
+                            **pred_field
+                        }
+                    },
+                    "sift4g": {
+                        "properties": {
+                            **score_field,
+                            **pred_field
+                        }
+                    },
+                    "polyphen2": {
+                        "properties": {
+                            "hdiv": {
+                                "properties": {
+                                    **score_field,
+                                    **pred_field
+                                }
+                            },
+                            "hvar": {
+                                "properties": {
+                                    **score_field,
+                                    **pred_field
+                                }
+                            }
+                        }
+                    },
+                    "mutationassessor": {
+                        "properties": {
+                            **score_field,
+                            **pred_field,
+                        }
+                    },
+                    "provean": {
+                        "properties": {
+                            **score_field,
+                            **pred_field
+                        }
+                    },
+                    "vest4": {
+                        "properties": {
+                            **score_field,
+                        }
+                    },
+                    "revel": {
+                        "properties": {
+                            **score_field,
+                        }
+                    },
+                    "mvp": {
+                        "properties": {
+                            **score_field,
+                        }
+                    },
+                    "gmvp": {
+                        "properties": {
+                            **score_field,
+                        }
+                    },
+                    "mpc": {
+                        "properties": {
+                            **score_field,
+                        }
+                    },
+                    "aloft": {
+                        "properties": {
+                            "fraction_transcripts_affected": keyword_value_field,
+                            "prob_tolerant": keyword_value_field,
+                            "prob_recessive": keyword_value_field,
+                            "prob_dominant": keyword_value_field,
+                            "pred": keyword_value_field,
+                            "confidence": {
+                                "type": "text"
+                            }
+                        }
+                    },
+                }
+            },
+            "cds_strand": keyword_value_field,
+            "ancestral_allele": keyword_value_field,
+            "altai_neandertal": keyword_value_field,
+            "denisova": keyword_value_field,
+            "vindijia_neandertal": keyword_value_field,
+            "chagyrskaya_neandertal": keyword_value_field,
+
+            "sift": {
+                "properties": {
+                    **converted_rankscore_field,
+                }
+            },
+            "sift4g": {
+                "properties": {
+                    **converted_rankscore_field,
+                }
+            },
+            "polyphen2": {
+                "properties": {
+                    "hdiv": {
+                        "properties": {
+                            **rankscore_field,
+                        }
+                    },
+                    "hvar": {
+                        "properties": {
+                            **rankscore_field,
+                        }
+                    }
+                }
+            },
+            # LRT retired by dbNSFP 5.0
+            "mutationtaster": {
+                # MutationTaster2021 (dbNSFP 5.0): MutationTaster_AAE retired, trees_benign/trees_deleterious added.
+                # model/pred/score/trees_benign/trees_deleterious are tupled per transcript row into "analysis";
+                # rankscore is a single dbNSFP-wide value and stays flat. See prune_mutation_taster().
+                "properties": {
+                    **rankscore_field,
+                    "analysis": {
+                        "properties": {
+                            **pred_field,
+                            **score_field,
+                            "model": keyword_value_field,
+                            "trees_benign": {
+                                "type": "integer"
+                            },
+                            "trees_deleterious": {
+                                "type": "integer"
+                            }
+                        }
+                    }
+                }
+            },
+            "mutationassessor": {
+                "properties": {
+                    **rankscore_field,
+                }
+            },
+            # FATHMM retired by dbNSFP 5.0
+            "provean": {
+                "properties": {
+                    **converted_rankscore_field,
+                }
+            },
+            "vest4": {
+                "properties": {
+                    **rankscore_field
+                }
+            },
+            "metasvm": {
+                "properties": {
+                    **score_field,
+                    **rankscore_field,
+                    **pred_field
+                }
+            },
+            "metalr": {
+                "properties": {
+                    **score_field,
+                    **rankscore_field,
+                    **pred_field
+                }
+            },
+            "reliability_index": {
+                "type": "integer"
+            },
+            "metarnn": {
+                "properties": {
+                    **score_field,
+                    **rankscore_field,
+                    **pred_field
+                }
+            },
+            "m-cap": {
+                "properties": {
+                    **score_field,
+                    **rankscore_field,
+                    **pred_field
+                }
+            },
+            "revel": {
+                "properties": {
+                    **rankscore_field
+                }
+            },
+            "mutpred2": {  # replaces MutPred (v1) in dbNSFP 5.2; not per-transcript, unlike most *_score fields
+                "properties": {
+                    **score_field,
+                    **rankscore_field,
+                    **pred_field,
+                    "mechanisms": {
+                        "properties": {
+                            "p_val": {
+                                "type": "float"
+                            },
+                            "mechanism": {
+                                "type": "text"
+                            }
+                        }
+                    }
+                }
+            },
+            "mvp": {
+                "properties": {
+                    **rankscore_field
+                }
+            },
+            "gmvp": {
+                "properties": {
+                    **rankscore_field
+                }
+            },
+            "misfit": {  # new in dbNSFP 5.3
+                "properties": {
+                    "d": {
+                        "properties": {
+                            **score_field,
+                            **rankscore_field,
+                            "pred_lenient": keyword_value_field,
+                            "pred_stringent": keyword_value_field
+                        }
+                    },
+                    "s": {
+                        "properties": {
+                            **score_field,
+                            **rankscore_field
+                        }
+                    }
+                }
+            },
+            "mpc": {
+                "properties": {
+                    **rankscore_field
+                }
+            },
+            "primateai": {
+                "properties": {
+                    **score_field,
+                    **rankscore_field,
+                    **pred_field
+                }
+            },
+            "deogen2": {
+                "properties": {
+                    **score_field,
+                    **rankscore_field,
+                    **pred_field
+                }
+            },
+            "bayesdel": {
+                "properties": {
+                    "add_af": {
+                        "properties": {
+                            **score_field,
+                            **rankscore_field,
+                            **pred_field
+                        }
+                    },
+                    "no_af": {
+                        "properties": {
+                            **score_field,
+                            **rankscore_field,
+                            **pred_field
+                        }
+                    }
+                }
+            },
+            "clinpred": {
+                "properties": {
+                    **score_field,
+                    **rankscore_field,
+                    **pred_field
+                }
+            },
+            "list-s2": {
+                "properties": {
+                    **score_field,
+                    **rankscore_field,
+                    **pred_field
+                }
+            },
+            "varity": {
+                "properties": {
+                    "r": {
+                        "properties": {
+                            **score_field,
+                            **rankscore_field
+                        }
+                    },
+                    "er": {
+                        "properties": {
+                            **score_field,
+                            **rankscore_field
+                        }
+                    },
+                    "r_loo": {
+                        "properties": {
+                            **score_field,
+                            **rankscore_field
+                        }
+                    },
+                    "er_loo": {
+                        "properties": {
+                            **score_field,
+                            **rankscore_field
+                        }
+                    }
+                }
+            },
+            "esm1b": {
+                "properties": {
+                    **score_field,
+                    **converted_rankscore_field,  # renamed from ESM1b_rankscore in dbNSFP 5.2
+                    **pred_field
+                }
+            },
+            # EVE retired by dbNSFP 5.0
+            "alphamissense": {
+                "properties": {
+                    **score_field,
+                    **rankscore_field,
+                    **pred_field
+                }
+            },
+            "phactboost": {
+                "properties": {
+                    **score_field,
+                    **rankscore_field
+                }
+            },
+            "mutformer": {
+                "properties": {
+                    **score_field,
+                    **rankscore_field
+                }
+            },
+            "mutscore": {  # new in dbNSFP 4.9a
+                "properties": {
+                    **score_field,
+                    **rankscore_field
+                }
+            },
+            "popeve": {  # new in dbNSFP 5.3.1
+                "properties": {
+                    **score_field,
+                    **pred_field,
+                    **converted_rankscore_field
+                }
+            },
+            "cadd": {
+                # Only for "hg38"
+                # No CADD fields will be included for "hg19"
+                "properties": {
+                    "raw_score": {
+                        "type": "float"
+                    },
+                    "raw_rankscore": {
+                        "type": "float"
+                    },
+                    "phred": {
+                        "type": "float"  # CADD phred-like scores, not as other predications of string type
+                    }
+                }
+            },
+            "dann": {
+                "properties": {
+                    **score_field,
+                    **rankscore_field
+                }
+            },
+            # fathmm-MKL retired by dbNSFP 5.0
+            "fathmm-xf": {
+                "properties": {
+                    "coding_score": {
+                        "type": "float"
+                    },
+                    "coding_rankscore": {
+                        "type": "float"
+                    },
+                    "coding_pred": keyword_value_field
+                }
+            },
+            "eigen": {
+                "properties": {
+                    "raw_coding": {
+                        "type": "float"
+                    },
+                    "raw_coding_rankscore": {
+                        "type": "float"
+                    },
+                    "phred_coding": {
+                        "type": "float"
+                    }
+                }
+            },
+            "eigen-pc": {
+                "properties": {
+                    "raw_coding": {
+                        "type": "float"
+                    },
+                    "raw_coding_rankscore": {
+                        "type": "float"
+                    },
+                    "phred_coding": {
+                        "type": "float"
+                    },
+                }
+            },
+            "gpn_msa": {  # new in dbNSFP 5.4
+                "properties": {
+                    **score_field,
+                    **converted_rankscore_field,
+                    **pred_field
+                }
+            },
+            # GenoCanyon retired by dbNSFP 5.0
+            # fitCons (integrated, GM12878, H1-hESC, HUVEC) retired by dbNSFP 5.0
+            # LINSIGHT retired by dbNSFP 5.0
+            "gerp++": {
+                "properties": {
+                    "nr": {
+                        "type": "float"
+                    },
+                    "rs": {
+                        "type": "float"
+                    },
+                    "rs_rankscore": {
+                        "type": "float"
+                    }
+                }
+            },
+            "gerp": {
+                "properties": {
+                    "92_mammals": {  # renamed from 91_mammals in dbNSFP 5.3
+                        "properties": {
+                            **score_field,
+                            **rankscore_field
+                        }
+                    }
+                }
+            },
+            "phylop": {
+                "properties": {
+                    "100way_vertebrate": {
+                        "properties": {
+                            **score_field,
+                            **rankscore_field
+                        }
+                    },
+                    "470way_mammalian": {
+                        "properties": {
+                            **score_field,
+                            **rankscore_field
+                        }
+                    },
+                    "17way_primate": {
+                        "properties": {
+                            **score_field,
+                            **rankscore_field
+                        }
+                    }
+                }
+            },
+            "phastcons": {
+                "properties": {
+                    "100way_vertebrate": {
+                        "properties": {
+                            **score_field,
+                            **rankscore_field
+                        }
+                    },
+                    "470way_mammalian": {
+                        "properties": {
+                            **score_field,
+                            **rankscore_field
+                        }
+                    },
+                    "17way_primate": {
+                        "properties": {
+                            **score_field,
+                            **rankscore_field
+                        }
+                    }
+                }
+            },
+            # SiPhy retired by dbNSFP 5.0
+            "bstatistic": {
+                "properties": {
+                    **score_field,
+                    **converted_rankscore_field
+                }
+            },
+            "1000gp3": {
+                "properties": {
+                    **allele_count_field,
+                    **allele_freq_field,
+                    "afr": {
+                        "properties": {
+                            **allele_count_field,
+                            **allele_freq_field
+                        }
+                    },
+                    "eur": {
+                        "properties": {
+                            **allele_count_field,
+                            **allele_freq_field
+                        }
+                    },
+                    "amr": {
+                        "properties": {
+                            **allele_count_field,
+                            **allele_freq_field
+                        }
+                    },
+                    "eas": {
+                        "properties": {
+                            **allele_count_field,
+                            **allele_freq_field
+                        }
+                    },
+                    "sas": {
+                        "properties": {
+                            **allele_count_field,
+                            **allele_freq_field
+                        }
+                    }
+                }
+            },
+            # TWINSUK, ALSPAC, UK10K, ESP6500, ExAC, ExAC_nonTCGA, ExAC_nonpsych retired by dbNSFP 5.0
+            # TOPMed freeze8, gnomAD2.1.1 exomes controls/non_neuro/non_cancer, gnomAD4.1 joint, All of Us, and
+            # RegeneronME are in the file but not parsed here (counted in VALID_COLUMN_NO only), consistent with
+            # gnomAD never being expanded into individual columns in earlier versions either (e.g. 4.8a)
+            "alfa": {
+                "properties": {
+                    "european": {
+                        "properties": {
+                            **allele_count_field,
+                            **allele_num_field,
+                            **allele_freq_field
+                        }
+                    },
+                    "african_others": {
+                        "properties": {
+                            **allele_count_field,
+                            **allele_num_field,
+                            **allele_freq_field
+                        }
+                    },
+                    "east_asian": {
+                        "properties": {
+                            **allele_count_field,
+                            **allele_num_field,
+                            **allele_freq_field
+                        }
+                    },
+                    "african_american": {
+                        "properties": {
+                            **allele_count_field,
+                            **allele_num_field,
+                            **allele_freq_field
+                        }
+                    },
+                    "latin_american_1": {
+                        "properties": {
+                            **allele_count_field,
+                            **allele_num_field,
+                            **allele_freq_field
+                        }
+                    },
+                    "latin_american_2": {
+                        "properties": {
+                            **allele_count_field,
+                            **allele_num_field,
+                            **allele_freq_field
+                        }
+                    },
+                    "other_asian": {
+                        "properties": {
+                            **allele_count_field,
+                            **allele_num_field,
+                            **allele_freq_field
+                        }
+                    },
+                    "south_asian": {
+                        "properties": {
+                            **allele_count_field,
+                            **allele_num_field,
+                            **allele_freq_field
+                        }
+                    },
+                    "other": {
+                        "properties": {
+                            **allele_count_field,
+                            **allele_num_field,
+                            **allele_freq_field
+                        }
+                    },
+                    "african": {
+                        "properties": {
+                            **allele_count_field,
+                            **allele_num_field,
+                            **allele_freq_field
+                        }
+                    },
+                    "asian": {
+                        "properties": {
+                            **allele_count_field,
+                            **allele_num_field,
+                            **allele_freq_field
+                        }
+                    },
+                    "total": {
+                        "properties": {
+                            **allele_count_field,
+                            **allele_num_field,
+                            **allele_freq_field
+                        }
+                    },
+                }
+            },
+            "clinvar": {
+                "properties": {
+                    "clinvar_id": keyword_value_field,
+                    "clnsig": keyword_value_field,
+                    "trait": keyword_value_field,
+                    "review": keyword_value_field,
+                    "hgvs": keyword_value_field,
+                    "var_source": keyword_value_field,
+                    "medgen": keyword_value_field,
+                    "omim": keyword_value_field,
+                    "orphanet": keyword_value_field
+                }
+            },
+            "interpro": {
+                "properties": {
+                    "domain": {
+                        "type": "text"
+                    }
+                }
+            },
+            "dbnsfp_popmax": {  # new in dbNSFP 5.1
+                "properties": {
+                    **allele_freq_field,
+                    **allele_count_field,
+                    "pop": keyword_value_field
+                }
+            }
+            # GTEx, eQTLGen, and Geuvadis eQTL columns retired by dbNSFP 5.0
+        }
+    }
+}

--- a/src/hub/dataload/sources/dbnsfp/dbnsfp_parser_54a_v1.py
+++ b/src/hub/dataload/sources/dbnsfp/dbnsfp_parser_54a_v1.py
@@ -1,0 +1,717 @@
+import re
+import csv
+from enum import Flag
+from dataclasses import dataclass
+from itertools import chain
+from typing import Callable
+from types import SimpleNamespace
+from utils.table import TableColumn, create_tag_column_map
+from utils.dotfield import parse_dot_fields
+from biothings.utils.common import anyfile
+
+
+# VALID_COLUMN_NO = 367  # for 4.1a
+# VALID_COLUMN_NO = 642  # for 4.2a
+# VALID_COLUMN_NO = 643  # for 4.3a
+# VALID_COLUMN_NO = 689  # for 4.4a
+# VALID_COLUMN_NO = 708  # for 4.5a
+# VALID_COLUMN_NO = 714  # for 4.6a
+# VALID_COLUMN_NO = 450  # for 4.7a
+# VALID_COLUMN_NO = 456  # for 4.8a
+# VALID_COLUMN_NO = 458  # for 4.9a
+# VALID_COLUMN_NO = 505  # for 5.3.1a
+VALID_COLUMN_NO = 508  # for 5.4a
+
+MUTPRED_TOP5FEATURES_PATTERN = re.compile(r" \(P = ([eE0-9.-]*)\)$")
+
+# dbNSFP_variant use "." for missing values;
+# other none values are borrowed from the `biothings.utils.dataload.dict_sweep` function and
+#   from the default `na_values` argument of pandas.read_csv().
+# see https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html
+NA_VALUES = frozenset({
+    r'.', r'', r" ", r"-", r'#N/A', r'#N/A N/A', r'#NA', r'-1.#IND', r'-1.#QNAN', r'-NaN', r'-nan',
+    r'1.#IND', r'1.#QNAN', r'<NA>', r'N/A', r'NA', r'NULL', r'NaN', r'n/a', r'nan', r'null', r'none',
+    r"Not Available", r"unknown"
+})
+
+COLUMN_TAG = SimpleNamespace()
+COLUMN_TAG.HG38_POS = "hg38_pos"  # for "pos(1-based)"
+COLUMN_TAG.HG19_POS = "hg19_pos"  # for "hg19_pos(1-based)"
+COLUMN_TAG.HG38_CHROM = "hg38_chrom"  # for "#chr"
+COLUMN_TAG.HG19_CHROM = "hg19_chrom"  # for "hg19_chr"
+COLUMN_TAG.REF_ALLELE = "ref"
+COLUMN_TAG.ALT_ALLELE = "alt"
+COLUMN_TAG.UNIPROT_ACC = "uniprot_acc"
+COLUMN_TAG.UNIPROT_ENTRY = "uniprot_entry"
+COLUMN_TAG.HGVS_CODING = "hgvsc"  # for "HGVSc_snpEff" and "HGVSc_VEP" (HGVSc_ANNOVAR present through dbNSFP 4.9a, retired by dbNSFP 5.0)
+COLUMN_TAG.HGVS_PROTEIN = "hgvsp"  # for "HGVSp_snpEff" and "HGVSp_VEP"
+# GTEx, eQTLGen, and Geuvadis eQTL columns retired by dbNSFP 5.0 (no longer in the variant file)
+
+
+def _check_length(lst: list):
+    """
+    If the input list is empty (i.e. length is 0), return None;
+    if the input list has only 1 element (i.e. length is 1), return the element;
+    otherwise return the list as-is.
+    """
+    if not lst:
+        return None
+    if len(lst) == 1:
+        return lst[0]
+    return lst
+
+
+class Assembly(Flag):
+    HG19 = 1  # indicates that a column belongs to hg19 docs
+    HG38 = 2  # indicates that a column belongs to hg38 docs
+    BOTH = HG19 | HG38  # (BOTH == 3) applies to both assemblies
+
+    @classmethod
+    def assembly_of(cls, name: str):
+        # E.g. when member_name == "HG19", member is Assembly.HG19
+        for member_name, member in cls.__members__.items():
+            if name.upper() == member_name:
+                return member
+        else:
+            raise ValueError(f"'{cls.__name__}' enum not found for '{name}'")
+
+
+@dataclass
+class Column(TableColumn):
+    """
+    Assembly-specific column configuration
+    """
+    assembly: str | Assembly = None  # which assembly or assemblies this column belongs to
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        if self.assembly is None:
+            self.assembly = Assembly.BOTH
+            return
+
+        if isinstance(self.assembly, Assembly):
+            return
+
+        if isinstance(self.assembly, str):
+            self.assembly = Assembly.assembly_of(self.assembly)
+            return
+
+        raise ValueError(f"Cannot recognize assembly {self.assembly}")
+
+    def is_hg19(self):
+        return bool(self.assembly & Assembly.HG19)  # true if self.assembly is HG19 or BOTH
+
+    def is_hg38(self):
+        return bool(self.assembly & Assembly.HG38)  # true if self.assembly is HG38 or BOTH
+
+
+def split(sep: str, na_values: set = NA_VALUES):
+    def _func(value: str):
+        result = [v for v in value.split(sep) if v not in na_values]
+        return _check_length(result)
+
+    return _func
+
+
+def split_cast(sep: str, astype: Callable, na_values: set = NA_VALUES):
+    def _func(value: str):
+        result = [astype(v) for v in value.split(sep) if v not in na_values]
+        return _check_length(result)
+
+    return _func
+
+
+# transforming functions for common data sources
+split_str = split(";")
+split_float = split_cast(";", float)
+split_int = split_cast(";", int)
+
+# transforming functions for specific data sources
+split_clinvar = split(r"|")
+split_genotype = split(r"/")  # for "AltaiNeandertal", "Denisova", "VindijiaNeandertal", and "ChagyrskayaNeandertal"
+
+
+def normalize_chrom(chr: str):
+    """
+    In dbNSFP, chromosomes are marked 1-22, "X", "Y", and "M" (Mitochondrial).
+    However, in MyVariant, we mark Mitochondrial chromosome "MT".
+    """
+    return "MT" if chr == "M" else chr
+
+
+def make_zero_based(pos: str):
+    """
+    Convert a 1-based chromosomal position to a 0-based start-end pair.
+    """
+    _pos = int(pos)
+    return {"start": _pos, "end": _pos}
+
+
+def parse_mutpred_top5features(value):
+    """
+    `mutpred_mechanisms` is a string combined from 5 clauses, separated by semicolons.
+    Each clause has the same pattern of "<mechanism> (P = <p_val>)".
+
+    E.g. "Loss of helix (P = 0.0444);Gain of loop (P = 0.0502);Gain of catalytic residue at A444 (P = 0.1876);\
+    Gain of solvent accessibility (P = 0.2291);Loss of disorder (P = 0.9475)"
+
+    Here we apply regex to parse this string and get a list of 5 tuples like
+
+        [('Loss of helix', '0.0444'), ('Gain of loop', '0.0502'), ('Gain of catalytic residue at A444', '0.1876'),
+        ('Gain of solvent accessibility', '0.2291'), ('Loss of disorder', '0.9475')]
+
+    Then construct a list of 5 dictionaries of <"mechanism": xxx, "p_val": xxx> and return
+    """
+    if value is None:
+        return None
+
+    mp_list = [tuple(e for e in MUTPRED_TOP5FEATURES_PATTERN.split(s) if e.strip()) for s in value.split(";")]
+    result = [{"mechanism": mp[0], "p_val": float(mp[1])} for mp in mp_list if mp and len(mp) == 2]
+
+    return _check_length(result)
+
+
+def split_zip(a_value: str, b_value: str, sep: str, na_values: set = NA_VALUES):
+    """
+    Split a_value and b_value by sep into two lists, and generate pairs from the two lists.
+
+    This function assumes that the split two lists have the same length.
+
+    E.g. with the following input,
+
+        a_value = "P54578-2;P54578-3;A6NJA2;P54578"
+        b_value = UBP14_HUMAN;UBP14_HUMAN;A6NJA2_HUMAN;UBP14_HUMAN
+
+    the returned generator can make:
+
+        [('P54578-2', 'UBP14_HUMAN'),
+         ('P54578-3', 'UBP14_HUMAN'),
+         ('A6NJA2', 'A6NJA2_HUMAN'),
+         ('P54578', 'UBP14_HUMAN')]
+    """
+    a_list = [v if v not in na_values else None for v in a_value.split(sep)]
+    b_list = [v if v not in na_values else None for v in b_value.split(sep)]
+
+    result = ((a, b) for (a, b) in zip(a_list, b_list) if (a, b) != (None, None))
+    # DO NOT use _check_length(result) otherwise the generator will be consumed
+    return result
+
+
+def split_dedup(values: list, sep: str, na_values: set = NA_VALUES):
+    """
+    Split each value from the input values by the separator, merge all the split results, and remove duplicates from the merged result.
+
+    E.g. when values=["a;b;c", "b;c", "d"] and sep=";", the result is ["a", "b", "c", "d"]
+    """
+    value_list = [value.split(sep=sep) for value in values]  # a list of lists
+    value_set = set(chain.from_iterable(value_list))  # flatten and dedup
+
+    result = list(v for v in value_set if v not in na_values)
+    return _check_length(result)
+
+
+COLUMNS = [
+    Column("#chr", dest="chrom", transform=normalize_chrom, assembly="hg38", tag=COLUMN_TAG.HG38_CHROM),  # representing "chrom" only for assembly 'hg38'
+    Column("pos(1-based)", dest="hg38", transform=make_zero_based, tag=COLUMN_TAG.HG38_POS),
+    Column("ref", transform=str.upper, tag=COLUMN_TAG.REF_ALLELE),
+    Column("alt", transform=str.upper, tag=COLUMN_TAG.ALT_ALLELE),
+    Column("aaref", dest="aa.ref"),
+    Column("aaalt", dest="aa.alt"),
+    Column("rs_dbSNP", dest="rsid"),
+    Column("hg19_chr", dest="chrom", transform=normalize_chrom, assembly="hg19", tag=COLUMN_TAG.HG19_CHROM),  # representing "chrom" only for assembly 'hg19'
+    Column("hg19_pos(1-based)", dest="hg19", transform=make_zero_based, tag=COLUMN_TAG.HG19_POS),
+    # Column("hg18_chr"),  # Not Used
+    Column("hg18_pos(1-based)", dest="hg18", transform=make_zero_based),
+    # Column("hs1_chr"),  # Not Used, same rationale as hg18_chr above (chrom label doesn't vary by build)
+    Column("hs1_pos(1-based)", dest="hs1", transform=make_zero_based),  # hs1/T2T-CHM13 v2.0 coordinates, added in dbNSFP 5.3.1; stored on both hg19 and hg38 docs like hg18
+    Column("aapos", dest="aa.pos", transform=split_int),
+    Column("genename", transform=split_str),
+    Column("Ensembl_geneid", transform=split_str),
+    Column("Ensembl_transcriptid", transform=split_str),
+    Column("Ensembl_proteinid", transform=split_str),
+    Column("Uniprot_acc", tag=COLUMN_TAG.UNIPROT_ACC),  # special column, see prune_uniprot()
+    Column("Uniprot_entry", tag=COLUMN_TAG.UNIPROT_ENTRY),  # special column, see prune_uniprot()
+    # HGVSc_ANNOVAR and HGVSp_ANNOVAR retired by dbNSFP 5.0; only snpEff and VEP sources remain
+    Column("HGVSc_snpEff", tag=COLUMN_TAG.HGVS_CODING),  # special column, see prune_hgvsc_hgvsp()
+    Column("HGVSp_snpEff", tag=COLUMN_TAG.HGVS_PROTEIN),  # ditto
+    Column("HGVSc_VEP", tag=COLUMN_TAG.HGVS_CODING),  # ditto
+    Column("HGVSp_VEP", tag=COLUMN_TAG.HGVS_PROTEIN),  # ditto
+    Column("APPRIS", transform=split_str),
+    Column("GENCODE_basic", dest="gencode_basic", transform=split_str),
+    Column("TSL", transform=split_int),
+    Column("Ensembl_canonical", dest="ensembl_canonical", transform=split_str),  # renamed from VEP_canonical in dbNSFP 5.4
+    Column("MANE", transform=split_str),  # added in dbNSFP 5.0
+    Column("cds_strand", dest="cds_strand", transform=split_str),
+    Column("refcodon", dest="aa.refcodon", transform=split_str),
+    Column("codonpos", dest="aa.codonpos", transform=split_int),
+    Column("codon_degeneracy", dest="aa.codon_degeneracy", transform=split_int),
+    Column("Ancestral_allele", dest="ancestral_allele", transform=split_str),
+    Column("AltaiNeandertal", dest="altai_neandertal", transform=split_genotype),
+    Column("Denisova", transform=split_genotype),
+    Column("VindijiaNeandertal", dest="vindijia_neandertal", transform=split_genotype),
+    Column("ChagyrskayaNeandertal", dest="chagyrskaya_neandertal", transform=split_genotype),
+    # Note: clinvar and Interpro_domain appear at different column positions than in dbNSFP 4.9a; no code impact (DictReader is order-independent)
+    Column("clinvar_id", dest="clinvar.clinvar_id", transform=split_clinvar),
+    Column("clinvar_clnsig", transform=split_clinvar),
+    Column("clinvar_trait", transform=split_clinvar),
+    Column("clinvar_review", transform=split_clinvar),
+    Column("clinvar_hgvs", transform=split_clinvar),
+    Column("clinvar_var_source", dest="clinvar.var_source", transform=split_clinvar),
+    Column("clinvar_MedGen_id", dest="clinvar.medgen", transform=split_clinvar),
+    Column("clinvar_OMIM_id", dest="clinvar.omim", transform=split_clinvar),
+    Column("clinvar_Orphanet_id", dest="clinvar.orphanet", transform=split_clinvar),
+    Column("Interpro_domain", transform=split_str),
+    Column("SIFT_score", transform=split_float),
+    Column("SIFT_converted_rankscore", dest="sift.converted_rankscore", transform=split_float),
+    Column("SIFT_pred", transform=split_str),
+    Column("SIFT4G_score", transform=split_float),
+    Column("SIFT4G_converted_rankscore", dest="sift4g.converted_rankscore", transform=split_float),
+    Column("SIFT4G_pred", transform=split_str),
+    Column("Polyphen2_HDIV_score", transform=split_float),
+    Column("Polyphen2_HDIV_rankscore", transform=split_float),
+    Column("Polyphen2_HDIV_pred", transform=split_str),
+    Column("Polyphen2_HVAR_score", transform=split_float),
+    Column("Polyphen2_HVAR_rankscore", transform=split_float),
+    Column("Polyphen2_HVAR_pred", transform=split_str),
+    # LRT retired by dbNSFP 5.0
+    Column("MutationTaster_score", transform=split_float),
+    Column("MutationTaster_rankscore", dest="mutationtaster.rankscore", transform=split_float),  # renamed from MutationTaster_converted_rankscore when dbNSFP 5.0 adopted MutationTaster2021
+    Column("MutationTaster_pred", transform=split_str),
+    Column("MutationTaster_model", transform=split_str),
+    Column("MutationTaster_trees_benign", dest="mutationtaster.trees_benign", transform=split_int),  # added in dbNSFP 5.0 (MutationTaster2021 random-forest tree counts)
+    Column("MutationTaster_trees_deleterious", dest="mutationtaster.trees_deleterious", transform=split_int),  # ditto
+    # MutationTaster_AAE retired by dbNSFP 5.0 (tied to the pre-2021 MutationTaster model)
+    Column("MutationAssessor_score", transform=split_float),
+    Column("MutationAssessor_rankscore", transform=split_float),
+    Column("MutationAssessor_pred", transform=split_str),
+    Column("PROVEAN_score", transform=split_float),
+    Column("PROVEAN_converted_rankscore", dest="provean.converted_rankscore", transform=split_float),
+    Column("PROVEAN_pred", transform=split_str),
+    # FATHMM retired by dbNSFP 5.0
+    Column("VEST4_score", transform=split_float),
+    Column("VEST4_rankscore", transform=split_float),
+    Column("MetaSVM_score", transform=split_float),
+    Column("MetaSVM_rankscore", transform=split_float),
+    Column("MetaSVM_pred", transform=split_str),
+    Column("MetaLR_score", transform=split_float),
+    Column("MetaLR_rankscore", transform=split_float),
+    Column("MetaLR_pred", transform=split_str),
+    Column("Reliability_index", dest="reliability_index", transform=int),
+    Column("MetaRNN_score", transform=split_float),
+    Column("MetaRNN_rankscore", transform=split_float),
+    Column("MetaRNN_pred", transform=split_str),
+    Column("M-CAP_score", transform=split_float),
+    Column("M-CAP_rankscore", transform=split_float),
+    Column("M-CAP_pred", transform=split_str),
+    Column("REVEL_score", transform=split_float),
+    Column("REVEL_rankscore", transform=split_float),
+    # MutPred (v1) replaced by MutPred2 in dbNSFP 5.2
+    Column("MutPred2_score", dest="mutpred2.score", transform=split_float),  # added in dbNSFP 5.2
+    Column("MutPred2_rankscore", dest="mutpred2.rankscore", transform=split_float),  # added in dbNSFP 5.2
+    Column("MutPred2_pred", dest="mutpred2.pred", transform=split_str),  # added in dbNSFP 5.2
+    Column("MutPred2_top5_mechanisms", dest="mutpred2.mechanisms", transform=parse_mutpred_top5features),  # added in dbNSFP 5.2
+    Column("MVP_score", transform=split_float),
+    Column("MVP_rankscore", transform=split_float),
+    Column("gMVP_score", transform=split_float),
+    Column("gMVP_rankscore", transform=split_float),
+    Column("MisFit_D_score", dest="misfit.d.score", transform=split_float),  # added in dbNSFP 5.3
+    Column("MisFit_D_rankscore", dest="misfit.d.rankscore", transform=split_float),  # added in dbNSFP 5.3
+    Column("MisFit_D_pred_lenient", dest="misfit.d.pred_lenient", transform=split_str),  # added in dbNSFP 5.3
+    Column("MisFit_D_pred_stringent", dest="misfit.d.pred_stringent", transform=split_str),  # added in dbNSFP 5.3
+    Column("MisFit_S_score", dest="misfit.s.score", transform=split_float),  # added in dbNSFP 5.3
+    Column("MisFit_S_rankscore", dest="misfit.s.rankscore", transform=split_float),  # added in dbNSFP 5.3
+    Column("MPC_score", transform=split_float),
+    Column("MPC_rankscore", transform=split_float),
+    Column("PrimateAI_score", transform=split_float),
+    Column("PrimateAI_rankscore", transform=split_float),
+    Column("PrimateAI_pred", transform=split_str),
+    Column("DEOGEN2_score", transform=split_float),
+    Column("DEOGEN2_rankscore", transform=split_float),
+    Column("DEOGEN2_pred", transform=split_str),
+    Column("BayesDel_addAF_score", dest="bayesdel.add_af.score", transform=split_float),
+    Column("BayesDel_addAF_rankscore", dest="bayesdel.add_af.rankscore", transform=split_float),
+    Column("BayesDel_addAF_pred", dest="bayesdel.add_af.pred", transform=split_str),
+    Column("BayesDel_noAF_score", dest="bayesdel.no_af.score", transform=split_float),
+    Column("BayesDel_noAF_rankscore", dest="bayesdel.no_af.rankscore", transform=split_float),
+    Column("BayesDel_noAF_pred", dest="bayesdel.no_af.pred", transform=split_str),
+    Column("ClinPred_score", transform=split_float),
+    Column("ClinPred_rankscore", transform=split_float),
+    Column("ClinPred_pred", transform=split_str),
+    Column("LIST-S2_score", transform=split_float),
+    Column("LIST-S2_rankscore", transform=split_float),
+    Column("LIST-S2_pred", transform=split_str),
+    Column("VARITY_R_score", transform=split_float),
+    Column("VARITY_R_rankscore", transform=split_float),
+    Column("VARITY_ER_score", transform=split_float),
+    Column("VARITY_ER_rankscore", transform=split_float),
+    Column("VARITY_R_LOO_score", dest="varity.r_loo.score", transform=split_float),
+    Column("VARITY_R_LOO_rankscore", dest="varity.r_loo.rankscore", transform=split_float),
+    Column("VARITY_ER_LOO_score", dest="varity.er_loo.score", transform=split_float),
+    Column("VARITY_ER_LOO_rankscore", dest="varity.er_loo.rankscore", transform=split_float),
+    Column("ESM1b_score", dest="esm1b.score", transform=split_float),
+    Column("ESM1b_converted_rankscore", dest="esm1b.converted_rankscore", transform=split_float),  # renamed from ESM1b_rankscore when dbNSFP 5.2 updated ESM1b scoring
+    Column("ESM1b_pred", dest="esm1b.pred", transform=split_str),
+    # EVE retired by dbNSFP 5.0
+    Column("AlphaMissense_score", dest="alphamissense.score", transform=split_float),
+    Column("AlphaMissense_rankscore", dest="alphamissense.rankscore", transform=split_float),
+    Column("AlphaMissense_pred", dest="alphamissense.pred", transform=split_str),
+    Column("PHACTboost_score", dest="phactboost.score", transform=split_float),
+    Column("PHACTboost_rankscore", dest="phactboost.rankscore", transform=split_float),
+    Column("MutFormer_score", dest="mutformer.score", transform=split_float),
+    Column("MutFormer_rankscore", dest="mutformer.rankscore", transform=split_float),
+    Column("MutScore_score", dest="mutscore.score", transform=split_float),
+    Column("MutScore_rankscore", dest="mutscore.rankscore", transform=split_float),
+    Column("popEVE_score", dest="popeve.score", transform=split_float),  # new in 5.3.1a
+    Column("popEVE_pred", dest="popeve.pred", transform=split_str),  # new in 5.3.1a
+    Column("popEVE_converted_rankscore", dest="popeve.converted_rankscore", transform=split_float),  # new in 5.3.1a
+    Column("Aloft_Fraction_transcripts_affected", dest="aloft.fraction_transcripts_affected", transform=split_str),
+    Column("Aloft_prob_Tolerant", dest="aloft.prob_tolerant", transform=split_str),
+    Column("Aloft_prob_Recessive", dest="aloft.prob_recessive", transform=split_str),
+    Column("Aloft_prob_Dominant", dest="aloft.prob_dominant", transform=split_str),
+    Column("Aloft_pred", transform=split_str),
+    Column("Aloft_Confidence", transform=split_str),
+    Column("CADD_raw", dest="cadd.raw_score", transform=split_float, assembly="hg38"),
+    Column("CADD_raw_rankscore", dest="cadd.raw_rankscore", transform=split_float, assembly="hg38"),
+    Column("CADD_phred", transform=split_float, assembly="hg38"),
+    Column("DANN_score", transform=split_float),
+    Column("DANN_rankscore", transform=split_float),
+    # fathmm-MKL retired by dbNSFP 5.0
+    Column("fathmm-XF_coding_score", dest="fathmm-xf.coding_score", transform=split_float),
+    Column("fathmm-XF_coding_rankscore", dest="fathmm-xf.coding_rankscore", transform=split_float),
+    Column("fathmm-XF_coding_pred", dest="fathmm-xf.coding_pred", transform=split_str),
+    Column("Eigen-raw_coding", dest="eigen.raw_coding", transform=split_float),
+    Column("Eigen-raw_coding_rankscore", dest="eigen.raw_coding_rankscore", transform=split_float),
+    Column("Eigen-phred_coding", dest="eigen.phred_coding", transform=split_float),
+    Column("Eigen-PC-raw_coding", dest="eigen-pc.raw_coding", transform=split_float),
+    Column("Eigen-PC-raw_coding_rankscore", dest="eigen-pc.raw_coding_rankscore", transform=split_float),
+    Column("Eigen-PC-phred_coding", dest="eigen-pc.phred_coding", transform=split_float),
+    Column("GPN_MSA_score", dest="gpn_msa.score", transform=split_float),  # added in dbNSFP 5.4
+    Column("GPN_MSA_converted_rankscore", dest="gpn_msa.converted_rankscore", transform=split_float),  # ditto
+    Column("GPN_MSA_pred", dest="gpn_msa.pred", transform=split_str),  # ditto
+    # GenoCanyon retired by dbNSFP 5.0
+    # fitCons (integrated, GM12878, H1-hESC, HUVEC) retired by dbNSFP 5.0
+    # LINSIGHT retired by dbNSFP 5.0
+    Column("GERP++_NR", transform=split_float),
+    Column("GERP++_RS", transform=split_float),
+    Column("GERP++_RS_rankscore", dest="gerp++.rs_rankscore", transform=split_float),
+    Column("GERP_92_mammals", dest="gerp.92_mammals.score", transform=split_float),  # added as GERP_91_mammals in dbNSFP 4.8; renamed to GERP_92_mammals in dbNSFP 5.3
+    Column("GERP_92_mammals_rankscore", dest="gerp.92_mammals.rankscore", transform=split_float),  # ditto
+    Column("phyloP100way_vertebrate", dest="phylop.100way_vertebrate.score", transform=split_float),
+    Column("phyloP100way_vertebrate_rankscore", dest="phylop.100way_vertebrate.rankscore", transform=split_float),
+    Column("phyloP470way_mammalian", dest="phylop.470way_mammalian.score", transform=split_float),
+    Column("phyloP470way_mammalian_rankscore", dest="phylop.470way_mammalian.rankscore", transform=split_float),
+    Column("phyloP17way_primate", dest="phylop.17way_primate.score", transform=split_float),
+    Column("phyloP17way_primate_rankscore", dest="phylop.17way_primate.rankscore", transform=split_float),
+    Column("phastCons100way_vertebrate", dest="phastcons.100way_vertebrate.score", transform=split_float),
+    Column("phastCons100way_vertebrate_rankscore", dest="phastcons.100way_vertebrate.rankscore", transform=split_float),
+    Column("phastCons470way_mammalian", dest="phastcons.470way_mammalian.score", transform=split_float),
+    Column("phastCons470way_mammalian_rankscore", dest="phastcons.470way_mammalian.rankscore", transform=split_float),
+    Column("phastCons17way_primate", dest="phastcons.17way_primate.score", transform=split_float),
+    Column("phastCons17way_primate_rankscore", dest="phastcons.17way_primate.rankscore", transform=split_float),
+    # SiPhy retired by dbNSFP 5.0 (not in conservation score list: bStatistic, phyloP100way_vertebrate, phyloP470way_mammalian,
+    #   phyloP17way_primate, phastCons100way_vertebrate, phastCons470way_mammalian, phastCons17way_primate, GERP++, GERP_92)
+    Column("bStatistic", dest="bstatistic.score", transform=split_float),
+    Column("bStatistic_converted_rankscore", dest="bstatistic.converted_rankscore", transform=split_float),
+    Column("1000Gp3_AC", dest="1000gp3.ac", transform=int),
+    Column("1000Gp3_AF", dest="1000gp3.af", transform=float),
+    Column("1000Gp3_AFR_AC", dest="1000gp3.afr.ac", transform=int),
+    Column("1000Gp3_AFR_AF", dest="1000gp3.afr.af", transform=float),
+    Column("1000Gp3_EUR_AC", dest="1000gp3.eur.ac", transform=int),
+    Column("1000Gp3_EUR_AF", dest="1000gp3.eur.af", transform=float),
+    Column("1000Gp3_AMR_AC", dest="1000gp3.amr.ac", transform=int),
+    Column("1000Gp3_AMR_AF", dest="1000gp3.amr.af", transform=float),
+    Column("1000Gp3_EAS_AC", dest="1000gp3.eas.ac", transform=int),
+    Column("1000Gp3_EAS_AF", dest="1000gp3.eas.af", transform=float),
+    Column("1000Gp3_SAS_AC", dest="1000gp3.sas.ac", transform=int),
+    Column("1000Gp3_SAS_AF", dest="1000gp3.sas.af", transform=float),
+    # TWINSUK, ALSPAC, UK10K, ESP6500, ExAC, ExAC_nonTCGA, ExAC_nonpsych retired by dbNSFP 5.0
+    # TOPMed freeze8 (3 cols, added 5.0), gnomAD2.1.1 exomes controls/non_neuro/non_cancer (109 cols, added 5.0),
+    # gnomAD4.1 joint (45 cols, updated to v4.1 in 5.0), All of Us (28 cols, added 5.1), and RegeneronME (84 cols,
+    # added 5.1) are in the file but not parsed here (counted in VALID_COLUMN_NO only), consistent with gnomAD
+    # never being expanded into individual columns in earlier versions either (e.g. 4.8a)
+    Column("ALFA_European_AC", dest="alfa.european.ac", transform=int),
+    Column("ALFA_European_AN", dest="alfa.european.an", transform=int),
+    Column("ALFA_European_AF", dest="alfa.european.af", transform=float),
+    Column("ALFA_African_Others_AC", dest="alfa.african_others.ac", transform=int),
+    Column("ALFA_African_Others_AN", dest="alfa.african_others.an", transform=int),
+    Column("ALFA_African_Others_AF", dest="alfa.african_others.af", transform=float),
+    Column("ALFA_East_Asian_AC", dest="alfa.east_asian.ac", transform=int),
+    Column("ALFA_East_Asian_AN", dest="alfa.east_asian.an", transform=int),
+    Column("ALFA_East_Asian_AF", dest="alfa.east_asian.af", transform=float),
+    Column("ALFA_African_American_AC", dest="alfa.african_american.ac", transform=int),
+    Column("ALFA_African_American_AN", dest="alfa.african_american.an", transform=int),
+    Column("ALFA_African_American_AF", dest="alfa.african_american.af", transform=float),
+    Column("ALFA_Latin_American_1_AC", dest="alfa.latin_american_1.ac", transform=int),
+    Column("ALFA_Latin_American_1_AN", dest="alfa.latin_american_1.an", transform=int),
+    Column("ALFA_Latin_American_1_AF", dest="alfa.latin_american_1.af", transform=float),
+    Column("ALFA_Latin_American_2_AC", dest="alfa.latin_american_2.ac", transform=int),
+    Column("ALFA_Latin_American_2_AN", dest="alfa.latin_american_2.an", transform=int),
+    Column("ALFA_Latin_American_2_AF", dest="alfa.latin_american_2.af", transform=float),
+    Column("ALFA_Other_Asian_AC", dest="alfa.other_asian.ac", transform=int),
+    Column("ALFA_Other_Asian_AN", dest="alfa.other_asian.an", transform=int),
+    Column("ALFA_Other_Asian_AF", dest="alfa.other_asian.af", transform=float),
+    Column("ALFA_South_Asian_AC", dest="alfa.south_asian.ac", transform=int),
+    Column("ALFA_South_Asian_AN", dest="alfa.south_asian.an", transform=int),
+    Column("ALFA_South_Asian_AF", dest="alfa.south_asian.af", transform=float),
+    Column("ALFA_Other_AC", dest="alfa.other.ac", transform=int),
+    Column("ALFA_Other_AN", dest="alfa.other.an", transform=int),
+    Column("ALFA_Other_AF", dest="alfa.other.af", transform=float),
+    Column("ALFA_African_AC", dest="alfa.african.ac", transform=int),
+    Column("ALFA_African_AN", dest="alfa.african.an", transform=int),
+    Column("ALFA_African_AF", dest="alfa.african.af", transform=float),
+    Column("ALFA_Asian_AC", dest="alfa.asian.ac", transform=int),
+    Column("ALFA_Asian_AN", dest="alfa.asian.an", transform=int),
+    Column("ALFA_Asian_AF", dest="alfa.asian.af", transform=float),
+    Column("ALFA_Total_AC", dest="alfa.total.ac", transform=int),
+    Column("ALFA_Total_AN", dest="alfa.total.an", transform=int),
+    Column("ALFA_Total_AF", dest="alfa.total.af", transform=float),
+    # dbNSFP-computed POPMAX across all population databases (added in dbNSFP 5.1)
+    Column("dbNSFP_POPMAX_AF", dest="dbnsfp_popmax.af", transform=float),
+    Column("dbNSFP_POPMAX_AC", dest="dbnsfp_popmax.ac", transform=int),
+    Column("dbNSFP_POPMAX_POP", dest="dbnsfp_popmax.pop"),
+    # GTEx, eQTLGen, and Geuvadis eQTL columns retired by dbNSFP 5.0
+]
+
+HG19_COLUMNS = [c for c in COLUMNS if c.is_hg19()]
+HG38_COLUMNS = [c for c in COLUMNS if c.is_hg38()]
+
+# Currently not necessary to make assembly-specific tag-column maps.
+TAG_COLUMN_MAP = create_tag_column_map(COLUMNS)
+
+
+def verify_pos(row, pos_column: Column, na_values: set = NA_VALUES):
+    pos_value = row[pos_column.name]
+
+    if pos_value in na_values:
+        return False
+
+    return True
+
+
+def verify_hg19_row(row: dict, na_values: set = NA_VALUES):
+    pos_column = TAG_COLUMN_MAP[COLUMN_TAG.HG19_POS][0]
+    return verify_pos(row, pos_column=pos_column, na_values=na_values)
+
+
+def verify_hg38_row(row: dict, na_values: set = NA_VALUES):
+    pos_column = TAG_COLUMN_MAP[COLUMN_TAG.HG38_POS][0]
+    return verify_pos(row, pos_column=pos_column, na_values=na_values)
+
+
+def prune_uniprot(raw_doc: dict, acc_column: Column, entry_column: Column, na_values: set = NA_VALUES):
+    """
+    Map each UniProt accession number and entry name from the raw document into a dictionary,
+    and assign all such dictionaries to the raw document's top "uniprot" field.
+
+    E.g. with the following input value:
+
+        raw_doc["uniprot.acc"] = "P54578-2;P54578-3;A6NJA2;P54578"
+        raw_doc["uniprot.entry"] = "UBP14_HUMAN;UBP14_HUMAN;A6NJA2_HUMAN;UBP14_HUMAN"
+
+    raw_doc will be assigned as:
+
+        raw_doc["uniprot"] = [
+            {'acc': 'P54578-2', 'entry': 'UBP14_HUMAN'},
+            {'acc': 'P54578-3', 'entry': 'UBP14_HUMAN'},
+            {'acc': 'A6NJA2', 'entry': 'A6NJA2_HUMAN'},
+            {'acc': 'P54578', 'entry': 'UBP14_HUMAN'}
+        ]
+    """
+    if (acc_column.dest in raw_doc) and (entry_column.dest in raw_doc):
+        acc_value = raw_doc[acc_column.dest]
+        entry_value = raw_doc[entry_column.dest]
+
+        uniprot_result = [{"acc": acc, "entry": entry} for (acc, entry) in split_zip(acc_value, entry_value, sep=";", na_values=na_values)]
+        uniprot_result = _check_length(uniprot_result)
+        if uniprot_result is not None:
+            raw_doc["uniprot"] = uniprot_result
+
+        del raw_doc[acc_column.dest]
+        del raw_doc[entry_column.dest]
+
+    return raw_doc
+
+
+def prune_hgvsc_hgvsp(raw_doc: dict, hgvsc_columns: list[Column], hgvsp_columns: list[Column], na_values: set = NA_VALUES):
+    """
+    Split "HGVSc_snpEff" and "HGVSc_VEP" values into "hgvsc" field;
+    split "HGVSp_snpEff" and "HGVSp_VEP" values into "hgvsp" field.
+    (HGVSc_ANNOVAR and HGVSp_ANNOVAR were present through dbNSFP 4.9a, retired by dbNSFP 5.0)
+    """
+    coding_values = [raw_doc[c.dest] for c in hgvsc_columns if c.dest in raw_doc]
+    protein_values = [raw_doc[c.dest] for c in hgvsp_columns if c.dest in raw_doc]
+
+    coding_result = split_dedup(coding_values, sep=";", na_values=na_values)
+    protein_result = split_dedup(protein_values, sep=";", na_values=na_values)
+
+    if coding_result is not None:
+        raw_doc["hgvsc"] = coding_result
+    if protein_result is not None:
+        raw_doc["hgvsp"] = protein_result
+
+    for c in hgvsc_columns:
+        raw_doc.pop(c.dest, None)  # safely delete the key because it can be absent
+    for c in hgvsp_columns:
+        raw_doc.pop(c.dest, None)  # safely delete the key because it can be absent
+
+    return raw_doc
+
+
+def prune_hg19_doc(doc: dict, na_values: set = NA_VALUES):
+    uniprot_acc_column = TAG_COLUMN_MAP[COLUMN_TAG.UNIPROT_ACC][0]
+    uniprot_entry_column = TAG_COLUMN_MAP[COLUMN_TAG.UNIPROT_ENTRY][0]
+    doc = prune_uniprot(doc, acc_column=uniprot_acc_column, entry_column=uniprot_entry_column, na_values=na_values)
+
+    hgvs_coding_columns = TAG_COLUMN_MAP[COLUMN_TAG.HGVS_CODING]
+    hgvs_protein_columns = TAG_COLUMN_MAP[COLUMN_TAG.HGVS_PROTEIN]
+    doc = prune_hgvsc_hgvsp(doc, hgvsc_columns=hgvs_coding_columns, hgvsp_columns=hgvs_protein_columns, na_values=na_values)
+
+    return doc
+
+
+def prune_hg38_doc(doc: dict, na_values: set = NA_VALUES):
+    return prune_hg19_doc(doc, na_values=na_values)
+
+
+def construct_raw_doc(row: dict, columns: list, na_values: set = NA_VALUES):
+    """
+    Construct a raw dbnsfp doc from a dict-like row read from the csv file.
+    "Raw" means 1) the doc may contain dot fields that are not parsed, and 2) some values in the doc need further treatment/processing.
+
+    Args:
+        row: a dict representing a csv row's content
+        columns: a list of Column object indicating how to construct each column
+        na_values: a set of values seen as NA
+    Returns:
+        a dict representing the doc's json object
+    """
+    result = dict()
+
+    for column in columns:
+        value = row[column.name]
+        if value in na_values:
+            continue
+
+        value = column.transform(value)
+        if value is None:
+            continue
+
+        result[column.dest] = value
+
+    return result
+
+
+def construct_hg19_raw_doc(row: dict, na_values: set = NA_VALUES):
+    return construct_raw_doc(row, columns=HG19_COLUMNS, na_values=na_values)
+
+
+def construct_hg38_raw_doc(row: dict, na_values: set = NA_VALUES):
+    return construct_raw_doc(row, columns=HG38_COLUMNS, na_values=na_values)
+
+
+def make_hgvs_id(doc: dict, chrom_column: Column, pos_column: Column, ref_column: Column, alt_column: Column):
+    chrom_value = doc[chrom_column.dest]
+    pos_value = doc[pos_column.dest]["start"]  # see make_zero_based()
+    ref_value = doc[ref_column.dest]
+    alt_value = doc[alt_column.dest]
+
+    hgvs_id = "chr%s:g.%d%s>%s" % (chrom_value, pos_value, ref_value, alt_value)
+    return hgvs_id
+
+
+def make_hg19_hgvs_id(doc: dict):
+    chrom_column = TAG_COLUMN_MAP[COLUMN_TAG.HG19_CHROM][0]
+    pos_column = TAG_COLUMN_MAP[COLUMN_TAG.HG19_POS][0]
+    ref_column = TAG_COLUMN_MAP[COLUMN_TAG.REF_ALLELE][0]
+    alt_column = TAG_COLUMN_MAP[COLUMN_TAG.ALT_ALLELE][0]
+
+    return make_hgvs_id(doc, chrom_column=chrom_column, pos_column=pos_column, ref_column=ref_column, alt_column=alt_column)
+
+
+def make_hg38_hgvs_id(doc: dict):
+    chrom_column = TAG_COLUMN_MAP[COLUMN_TAG.HG38_CHROM][0]
+    pos_column = TAG_COLUMN_MAP[COLUMN_TAG.HG38_POS][0]
+    ref_column = TAG_COLUMN_MAP[COLUMN_TAG.REF_ALLELE][0]
+    alt_column = TAG_COLUMN_MAP[COLUMN_TAG.ALT_ALLELE][0]
+
+    return make_hgvs_id(doc, chrom_column=chrom_column, pos_column=pos_column, ref_column=ref_column, alt_column=alt_column)
+
+
+def construct_hg19_doc(row: dict, na_values: set = NA_VALUES):
+    verified = verify_hg19_row(row, na_values=na_values)
+    if not verified:
+        return None
+
+    raw_doc = construct_hg19_raw_doc(row, na_values=na_values)
+    raw_doc = prune_hg19_doc(raw_doc, na_values=na_values)
+    hgvs_id = make_hg19_hgvs_id(raw_doc)
+
+    doc = {
+        "_id": hgvs_id,
+        "dbnsfp": parse_dot_fields(raw_doc)  # convert dot-fields into nested dictionaries
+    }
+    return doc
+
+
+def construct_hg38_doc(row: dict, na_values: set = NA_VALUES):
+    verified = verify_hg38_row(row, na_values=na_values)
+    if not verified:
+        return None
+
+    raw_doc = construct_hg38_raw_doc(row, na_values=na_values)
+    raw_doc = prune_hg38_doc(raw_doc, na_values=na_values)
+    hgvs_id = make_hg38_hgvs_id(raw_doc)
+
+    doc = {
+        "_id": hgvs_id,
+        "dbnsfp": parse_dot_fields(raw_doc)  # convert dot-fields into nested dictionaries
+    }
+    return doc
+
+
+def load_file(path: str, assembly: str):
+    file = anyfile(path)
+    file_reader = csv.DictReader(file, delimiter="\t")
+
+    num_columns = len(file_reader.fieldnames)
+    if VALID_COLUMN_NO is not None:
+        assert num_columns == VALID_COLUMN_NO, "Expecting %s columns, but got %s" % (VALID_COLUMN_NO, num_columns)
+
+    _construct_doc = None
+    match assembly:
+        case "hg19":
+            _construct_doc = construct_hg19_doc
+        case "hg38":
+            _construct_doc = construct_hg38_doc
+        case _:
+            raise ValueError(f"Cannot recognize assembly. Accept 'hg19' or 'hg38', got '{assembly}'.")
+
+    last_doc = None
+    for row in file_reader:
+        current_doc = _construct_doc(row, na_values=NA_VALUES)
+
+        if current_doc is None:
+            continue
+
+        if last_doc is not None:
+            if current_doc["_id"] == last_doc["_id"]:
+                last_aa = last_doc["dbnsfp"]["aa"]
+                current_aa = current_doc["dbnsfp"]["aa"]
+
+                if not isinstance(last_aa, list):
+                    last_aa = [last_aa]
+                last_aa.append(current_aa)
+
+                last_doc["dbnsfp"]["aa"] = last_aa
+                continue
+            else:
+                yield last_doc
+
+        last_doc = current_doc
+
+    # yield the very last doc
+    if last_doc:
+        yield last_doc
+
+    file.close()

--- a/src/hub/dataload/sources/dbnsfp/dbnsfp_parser_54a_v2.py
+++ b/src/hub/dataload/sources/dbnsfp/dbnsfp_parser_54a_v2.py
@@ -1,0 +1,825 @@
+import re
+import csv
+from enum import Flag
+from dataclasses import dataclass
+from typing import Callable
+from types import SimpleNamespace
+from utils.table import TableColumn, create_tag_column_map
+from utils.dotfield import parse_dot_fields
+from biothings.utils.common import anyfile
+
+
+# VALID_COLUMN_NO = 367  # for 4.1a
+# VALID_COLUMN_NO = 642  # for 4.2a
+# VALID_COLUMN_NO = 643  # for 4.3a
+# VALID_COLUMN_NO = 689  # for 4.4a
+# VALID_COLUMN_NO = 708  # for 4.5a
+# VALID_COLUMN_NO = 714  # for 4.6a
+# VALID_COLUMN_NO = 450  # for 4.7a
+# VALID_COLUMN_NO = 456  # for 4.8a
+# VALID_COLUMN_NO = 458  # for 4.9a
+# VALID_COLUMN_NO = 505  # for 5.3.1a
+VALID_COLUMN_NO = 508  # for 5.4a
+
+MUTPRED_TOP5FEATURES_PATTERN = re.compile(r" \(P = ([eE0-9.-]*)\)$")
+
+# dbNSFP_variant use "." for missing values;
+# other none values are borrowed from the `biothings.utils.dataload.dict_sweep` function and
+#   from the default `na_values` argument of pandas.read_csv().
+# see https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html
+NA_VALUES = frozenset({
+    r'.', r'', r" ", r"-", r'#N/A', r'#N/A N/A', r'#NA', r'-1.#IND', r'-1.#QNAN', r'-NaN', r'-nan',
+    r'1.#IND', r'1.#QNAN', r'<NA>', r'N/A', r'NA', r'NULL', r'NaN', r'n/a', r'nan', r'null', r'none',
+    r"Not Available", r"unknown"
+})
+
+# A tag can be any string value; columns with the same tag are looked-up as a group
+COLUMN_TAG = SimpleNamespace()
+COLUMN_TAG.HG38_POS = "hg38_pos"  # for "pos(1-based)"
+COLUMN_TAG.HG19_POS = "hg19_pos"  # for "hg19_pos(1-based)"
+COLUMN_TAG.HG38_CHROM = "hg38_chrom"  # for "#chr"
+COLUMN_TAG.HG19_CHROM = "hg19_chrom"  # for "hg19_chr"
+COLUMN_TAG.REF_ALLELE = "ref"
+COLUMN_TAG.ALT_ALLELE = "alt"
+# GTEx, eQTLGen, and Geuvadis eQTL columns retired by dbNSFP 5.0 (no longer in the variant file)
+# MutationTaster_AAE retired and per-transcript tree count columns added when dbNSFP 5.0 adopted MutationTaster2021
+COLUMN_TAG.MUTATION_TASTER_MODEL = "MutationTaster_model"
+COLUMN_TAG.MUTATION_TASTER_PRED = "MutationTaster_pred"
+COLUMN_TAG.MUTATION_TASTER_SCORE = "MutationTaster_score"
+COLUMN_TAG.MUTATION_TASTER_TREES_BENIGN = "MutationTaster_trees_benign"
+COLUMN_TAG.MUTATION_TASTER_TREES_DELETERIOUS = "MutationTaster_trees_deleterious"
+COLUMN_TAG.ALOFT_FRACTION_TRANSCRIPTS_AFFECTED = "Aloft_Fraction_transcripts_affected"
+COLUMN_TAG.ALOFT_PROB_TOLERANT = "Aloft_prob_Tolerant"
+COLUMN_TAG.ALOFT_PROB_RECESSIVE = "Aloft_prob_Recessive"
+COLUMN_TAG.ALOFT_PROB_DOMINANT = "Aloft_prob_Dominant"
+COLUMN_TAG.ALOFT_PRED = "Aloft_pred"
+COLUMN_TAG.ALOFT_CONFIDENCE = "Aloft_Confidence"
+
+
+def _check_length(lst: list):
+    """
+    If the input list is empty (i.e. length is 0), return None;
+    if the input list has only 1 element (i.e. length is 1), return the element;
+    otherwise return the list as-is.
+    """
+    if not lst:
+        return None
+    if len(lst) == 1:
+        return lst[0]
+    return lst
+
+
+class Assembly(Flag):
+    HG19 = 1  # indicates that a column belongs to hg19 docs
+    HG38 = 2  # indicates that a column belongs to hg38 docs
+    BOTH = HG19 | HG38  # (BOTH == 3) applies to both assemblies
+
+    @classmethod
+    def assembly_of(cls, name: str):
+        # E.g. when member_name == "HG19", member is Assembly.HG19
+        for member_name, member in cls.__members__.items():
+            if name.upper() == member_name:
+                return member
+        else:
+            raise ValueError(f"'{cls.__name__}' enum not found for '{name}'")
+
+
+@dataclass
+class Column(TableColumn):
+    """
+    Assembly-specific column configuration
+    """
+    assembly: str | Assembly = None  # which assembly or assemblies this column belongs to
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        if self.assembly is None:
+            self.assembly = Assembly.BOTH
+            return
+
+        if isinstance(self.assembly, Assembly):
+            return
+
+        if isinstance(self.assembly, str):
+            self.assembly = Assembly.assembly_of(self.assembly)
+            return
+
+        raise ValueError(f"Cannot recognize assembly {self.assembly}")
+
+    def is_hg19(self):
+        return bool(self.assembly & Assembly.HG19)  # true if self.assembly is HG19 or BOTH
+
+    def is_hg38(self):
+        return bool(self.assembly & Assembly.HG38)  # true if self.assembly is HG38 or BOTH
+
+
+def split(sep: str, na_values: set = NA_VALUES, drop_na: bool = False):
+    def _func_drop_na(value: str):
+        result = [v for v in value.split(sep) if v not in na_values]
+        return result
+
+    def _func_keep_na(value: str):
+        result = [v if v not in na_values else None for v in value.split(sep)]
+        if all(v is None for v in result):  # we keep NA values in the result; however if every value in the result is None, we treat whole result as None
+            return None
+        return result
+
+    return _func_drop_na if drop_na else _func_keep_na
+
+
+def split_cast(sep: str, astype: Callable, na_values: set = NA_VALUES, drop_na: bool = False):
+    def _func_drop_na(value: str):
+        result = [astype(v) for v in value.split(sep) if v not in na_values]
+        return result
+
+    def _func_keep_na(value: str):
+        result = [astype(v) if v not in na_values else None for v in value.split(sep)]
+        if all(v is None for v in result):  # we keep NA values in the result; however if every value in the result is None, we treat whole result as None
+            return None
+        return result
+
+    return _func_drop_na if drop_na else _func_keep_na
+
+
+def compose(_split_func: Callable, _unlist_func: Callable):
+    def _func(value):
+        split_result = _split_func(value)
+        if split_result is None:
+            return None
+        return _unlist_func(split_result)
+    return _func
+
+
+# Transforming functions for "protein" data sources
+# We don't compose with _check_length because it would be easier to apply "zip" on the split results if all values are lists
+split_str = split(";")
+split_float = split_cast(";", float)
+split_int = split_cast(";", int)
+
+# Transforming functions for other common non-"protein" data sources
+split_str_drop_na = compose(split(";", drop_na=True), _check_length)
+split_float_drop_na = compose(split_cast(";", float, drop_na=True), _check_length)
+split_int_drop_na = compose(split_cast(";", int, drop_na=True), _check_length)
+
+# Transforming functions for specific data sources
+split_clinvar = compose(split(r"|", drop_na=True), _check_length)
+split_genotype = compose(split(r"/", drop_na=True), _check_length)  # for "AltaiNeandertal", "Denisova", "VindijiaNeandertal", and "ChagyrskayaNeandertal"
+
+
+def normalize_chrom(chr: str):
+    """
+    In dbNSFP, chromosomes are marked 1-22, "X", "Y", and "M" (Mitochondrial).
+    However, in MyVariant, we mark Mitochondrial chromosome "MT".
+    """
+    return "MT" if chr == "M" else chr
+
+
+def make_zero_based(pos: str):
+    """
+    Convert a 1-based chromosomal position to a 0-based start-end pair.
+    """
+    _pos = int(pos)
+    return {"start": _pos, "end": _pos}
+
+
+def parse_mutpred_top5features(value):
+    """
+    `mutpred_mechanisms` is a string combined from 5 clauses, separated by semicolons.
+    Each clause has the same pattern of "<mechanism> (P = <p_val>)".
+
+    E.g. "Loss of helix (P = 0.0444);Gain of loop (P = 0.0502);Gain of catalytic residue at A444 (P = 0.1876);\
+    Gain of solvent accessibility (P = 0.2291);Loss of disorder (P = 0.9475)"
+
+    Here we apply regex to parse this string and get a list of 5 tuples like
+
+        [('Loss of helix', '0.0444'), ('Gain of loop', '0.0502'), ('Gain of catalytic residue at A444', '0.1876'),
+        ('Gain of solvent accessibility', '0.2291'), ('Loss of disorder', '0.9475')]
+
+    Then construct a list of 5 dictionaries of <"mechanism": xxx, "p_val": xxx> and return
+    """
+    if value is None:
+        return None
+
+    mp_list = [tuple(e for e in MUTPRED_TOP5FEATURES_PATTERN.split(s) if e.strip()) for s in value.split(";")]
+    result = [{"mechanism": mp[0], "p_val": float(mp[1])} for mp in mp_list if mp and len(mp) == 2]
+
+    return _check_length(result)
+
+
+def split_zip(values: list[str], sep: str, na_values: set = NA_VALUES):
+    """
+    Split each string in values by sep into a list, and generate tuples from all the lists.
+
+    E.g. with the following input,
+
+        values = ["P54578-2;P54578-3;A6NJA2;P54578", "UBP14_HUMAN;UBP14_HUMAN;A6NJA2_HUMAN;UBP14_HUMAN"]
+
+    the returned generator can make:
+
+        [('P54578-2', 'UBP14_HUMAN'),
+         ('P54578-3', 'UBP14_HUMAN'),
+         ('A6NJA2', 'A6NJA2_HUMAN'),
+         ('P54578', 'UBP14_HUMAN')]
+
+    Reference implementation: https://docs.python.org/3.3/library/functions.html#zip
+    """
+    sentinel = object()
+    iterators = [(v if v not in na_values else None for v in value.split(sep)) for value in values]
+
+    while iterators:  # always true if iterators is not empty
+        result = []
+        for it in iterators:
+            element = next(it, sentinel)
+            if element is sentinel:  # terminate at once when a `it` is fully consumed
+                return
+            result.append(element)
+        yield tuple(result)
+
+
+COLUMNS = [
+    Column("#chr", dest="chrom", transform=normalize_chrom, assembly="hg38", tag=COLUMN_TAG.HG38_CHROM),  # representing "chrom" only for assembly 'hg38'
+    Column("pos(1-based)", dest="hg38", transform=make_zero_based, tag=COLUMN_TAG.HG38_POS),
+    Column("ref", transform=str.upper, tag=COLUMN_TAG.REF_ALLELE),
+    Column("alt", transform=str.upper, tag=COLUMN_TAG.ALT_ALLELE),
+    Column("aaref", dest="aa.ref"),
+    Column("aaalt", dest="aa.alt"),
+    Column("rs_dbSNP", dest="rsid"),
+    Column("hg19_chr", dest="chrom", transform=normalize_chrom, assembly="hg19", tag=COLUMN_TAG.HG19_CHROM),  # representing "chrom" only for assembly 'hg19'
+    Column("hg19_pos(1-based)", dest="hg19", transform=make_zero_based, tag=COLUMN_TAG.HG19_POS),
+    # Column("hg18_chr"),  # Not Used
+    Column("hg18_pos(1-based)", dest="hg18", transform=make_zero_based),
+    # Column("hs1_chr"),  # Not Used, same rationale as hg18_chr above (chrom label doesn't vary by build)
+    Column("hs1_pos(1-based)", dest="hs1", transform=make_zero_based),  # hs1/T2T-CHM13 v2.0 coordinates, added in dbNSFP 5.3.1; stored on both hg19 and hg38 docs like hg18
+    Column("aapos", dest="protein.aa.pos", transform=split_int),
+    Column("genename", dest="protein.genename", transform=split_str),
+    Column("Ensembl_geneid", dest="protein.geneid", transform=split_str),
+    Column("Ensembl_transcriptid", dest="protein.transcriptid", transform=split_str),
+    Column("Ensembl_proteinid", dest="protein.proteinid", transform=split_str),
+    Column("Uniprot_acc", dest="protein.uniprot.acc", transform=split_str),
+    Column("Uniprot_entry", dest="protein.uniprot.entry", transform=split_str),
+    # HGVSc_ANNOVAR and HGVSp_ANNOVAR retired by dbNSFP 5.0; only snpEff and VEP sources remain
+    Column("HGVSc_snpEff", dest="protein.hgvsc.snpeff", transform=split_str),
+    Column("HGVSp_snpEff", dest="protein.hgvsp.snpeff", transform=split_str),
+    Column("HGVSc_VEP", dest="protein.hgvsc.vep", transform=split_str),
+    Column("HGVSp_VEP", dest="protein.hgvsp.vep", transform=split_str),
+    Column("APPRIS", dest="protein.appris", transform=split_str),
+    Column("GENCODE_basic", dest="protein.gencode_basic", transform=split_str),
+    Column("TSL", dest="protein.tsl", transform=split_int),
+    Column("Ensembl_canonical", dest="protein.ensembl_canonical", transform=split_str),  # renamed from VEP_canonical in dbNSFP 5.4
+    Column("MANE", dest="protein.mane", transform=split_str),  # added in dbNSFP 5.0; per-transcript canonical designation
+    Column("cds_strand", dest="cds_strand", transform=split_str_drop_na),
+    Column("refcodon", dest="protein.aa.refcodon", transform=split_str),
+    Column("codonpos", dest="protein.aa.codonpos", transform=split_int),
+    Column("codon_degeneracy", dest="protein.aa.codon_degeneracy", transform=split_int),
+    Column("Ancestral_allele", dest="ancestral_allele", transform=split_str_drop_na),
+    Column("AltaiNeandertal", dest="altai_neandertal", transform=split_genotype),
+    Column("Denisova", transform=split_genotype),
+    Column("VindijiaNeandertal", dest="vindijia_neandertal", transform=split_genotype),
+    Column("ChagyrskayaNeandertal", dest="chagyrskaya_neandertal", transform=split_genotype),
+    # Note: clinvar and Interpro_domain appear at different column positions than in dbNSFP 4.9a; no code impact (DictReader is order-independent)
+    Column("clinvar_id", dest="clinvar.clinvar_id", transform=split_clinvar),
+    Column("clinvar_clnsig", transform=split_clinvar),
+    Column("clinvar_trait", transform=split_clinvar),
+    Column("clinvar_review", transform=split_clinvar),
+    Column("clinvar_hgvs", transform=split_clinvar),
+    Column("clinvar_var_source", dest="clinvar.var_source", transform=split_clinvar),
+    Column("clinvar_MedGen_id", dest="clinvar.medgen", transform=split_clinvar),
+    Column("clinvar_OMIM_id", dest="clinvar.omim", transform=split_clinvar),
+    Column("clinvar_Orphanet_id", dest="clinvar.orphanet", transform=split_clinvar),
+    Column("Interpro_domain", transform=split_str_drop_na),
+    Column("SIFT_score", dest="protein.sift.score", transform=split_float),
+    Column("SIFT_converted_rankscore", dest="sift.converted_rankscore", transform=split_float_drop_na),
+    Column("SIFT_pred", dest="protein.sift.pred", transform=split_str),
+    Column("SIFT4G_score", dest="protein.sift4g.score", transform=split_float),
+    Column("SIFT4G_converted_rankscore", dest="sift4g.converted_rankscore", transform=split_float_drop_na),
+    Column("SIFT4G_pred", dest="protein.sift4g.pred", transform=split_str),
+    Column("Polyphen2_HDIV_score", dest="protein.polyphen2.hdiv.score", transform=split_float),
+    Column("Polyphen2_HDIV_rankscore", transform=split_float_drop_na),
+    Column("Polyphen2_HDIV_pred", dest="protein.polyphen2.hdiv.pred", transform=split_str),
+    Column("Polyphen2_HVAR_score", dest="protein.polyphen2.hvar.score", transform=split_float),
+    Column("Polyphen2_HVAR_rankscore", transform=split_float_drop_na),
+    Column("Polyphen2_HVAR_pred", dest="protein.polyphen2.hvar.pred", transform=split_str),
+    # LRT retired by dbNSFP 5.0
+    Column("MutationTaster_score", tag=COLUMN_TAG.MUTATION_TASTER_SCORE),
+    Column("MutationTaster_rankscore", dest="mutationtaster.rankscore", transform=split_float_drop_na),  # renamed from MutationTaster_converted_rankscore when dbNSFP 5.0 adopted MutationTaster2021
+    Column("MutationTaster_pred", tag=COLUMN_TAG.MUTATION_TASTER_PRED),
+    Column("MutationTaster_model", tag=COLUMN_TAG.MUTATION_TASTER_MODEL),
+    Column("MutationTaster_trees_benign", tag=COLUMN_TAG.MUTATION_TASTER_TREES_BENIGN),  # added in dbNSFP 5.0; per-transcript benign tree count
+    Column("MutationTaster_trees_deleterious", tag=COLUMN_TAG.MUTATION_TASTER_TREES_DELETERIOUS),  # added in dbNSFP 5.0; per-transcript deleterious tree count
+    # MutationTaster_AAE retired by dbNSFP 5.0 (tied to the pre-2021 MutationTaster model)
+    Column("MutationAssessor_score", dest="protein.mutationassessor.score", transform=split_float),
+    Column("MutationAssessor_rankscore", transform=split_float_drop_na),
+    Column("MutationAssessor_pred", dest="protein.mutationassessor.pred", transform=split_str),
+    # FATHMM retired by dbNSFP 5.0
+    Column("PROVEAN_score", dest="protein.provean.score", transform=split_float),
+    Column("PROVEAN_converted_rankscore", dest="provean.converted_rankscore", transform=split_float_drop_na),
+    Column("PROVEAN_pred", dest="protein.provean.pred", transform=split_str),
+    Column("VEST4_score", dest="protein.vest4.score", transform=split_float),
+    Column("VEST4_rankscore", transform=split_float_drop_na),
+    Column("MetaSVM_score", transform=split_float_drop_na),
+    Column("MetaSVM_rankscore", transform=split_float_drop_na),
+    Column("MetaSVM_pred", transform=split_str_drop_na),
+    Column("MetaLR_score", transform=split_float_drop_na),
+    Column("MetaLR_rankscore", transform=split_float_drop_na),
+    Column("MetaLR_pred", transform=split_str_drop_na),
+    Column("Reliability_index", dest="reliability_index", transform=int),
+    Column("MetaRNN_score", transform=split_float_drop_na),
+    Column("MetaRNN_rankscore", transform=split_float_drop_na),
+    Column("MetaRNN_pred", transform=split_str_drop_na),
+    Column("M-CAP_score", transform=split_float_drop_na),
+    Column("M-CAP_rankscore", transform=split_float_drop_na),
+    Column("M-CAP_pred", transform=split_str_drop_na),
+    Column("REVEL_score", dest="protein.revel.score", transform=split_float),
+    Column("REVEL_rankscore", transform=split_float_drop_na),
+    # MutPred (v1) replaced by MutPred2 in dbNSFP 5.2
+    Column("MutPred2_score", dest="mutpred2.score", transform=split_float_drop_na),  # added in dbNSFP 5.2
+    Column("MutPred2_rankscore", dest="mutpred2.rankscore", transform=split_float_drop_na),  # added in dbNSFP 5.2
+    Column("MutPred2_pred", dest="mutpred2.pred", transform=split_str_drop_na),  # added in dbNSFP 5.2
+    Column("MutPred2_top5_mechanisms", dest="mutpred2.mechanisms", transform=parse_mutpred_top5features),  # added in dbNSFP 5.2
+    Column("MVP_score", dest="protein.mvp.score", transform=split_float),
+    Column("MVP_rankscore", transform=split_float_drop_na),
+    Column("gMVP_score", dest="protein.gmvp.score", transform=split_float),
+    Column("gMVP_rankscore", transform=split_float_drop_na),
+    Column("MisFit_D_score", dest="misfit.d.score", transform=split_float_drop_na),  # added in dbNSFP 5.3
+    Column("MisFit_D_rankscore", dest="misfit.d.rankscore", transform=split_float_drop_na),  # added in dbNSFP 5.3
+    Column("MisFit_D_pred_lenient", dest="misfit.d.pred_lenient", transform=split_str_drop_na),  # added in dbNSFP 5.3
+    Column("MisFit_D_pred_stringent", dest="misfit.d.pred_stringent", transform=split_str_drop_na),  # added in dbNSFP 5.3
+    Column("MisFit_S_score", dest="misfit.s.score", transform=split_float_drop_na),  # added in dbNSFP 5.3
+    Column("MisFit_S_rankscore", dest="misfit.s.rankscore", transform=split_float_drop_na),  # added in dbNSFP 5.3
+    Column("MPC_score", dest="protein.mpc.score", transform=split_float),
+    Column("MPC_rankscore", transform=split_float_drop_na),
+    Column("PrimateAI_score", transform=split_float_drop_na),
+    Column("PrimateAI_rankscore", transform=split_float_drop_na),
+    Column("PrimateAI_pred", transform=split_str_drop_na),
+    Column("DEOGEN2_score", transform=split_float_drop_na),
+    Column("DEOGEN2_rankscore", transform=split_float_drop_na),
+    Column("DEOGEN2_pred", transform=split_str_drop_na),
+    Column("BayesDel_addAF_score", dest="bayesdel.add_af.score", transform=split_float_drop_na),
+    Column("BayesDel_addAF_rankscore", dest="bayesdel.add_af.rankscore", transform=split_float_drop_na),
+    Column("BayesDel_addAF_pred", dest="bayesdel.add_af.pred", transform=split_str_drop_na),
+    Column("BayesDel_noAF_score", dest="bayesdel.no_af.score", transform=split_float_drop_na),
+    Column("BayesDel_noAF_rankscore", dest="bayesdel.no_af.rankscore", transform=split_float_drop_na),
+    Column("BayesDel_noAF_pred", dest="bayesdel.no_af.pred", transform=split_str_drop_na),
+    Column("ClinPred_score", transform=split_float_drop_na),
+    Column("ClinPred_rankscore", transform=split_float_drop_na),
+    Column("ClinPred_pred", transform=split_str_drop_na),
+    Column("LIST-S2_score", transform=split_float_drop_na),
+    Column("LIST-S2_rankscore", transform=split_float_drop_na),
+    Column("LIST-S2_pred", transform=split_str_drop_na),
+    Column("VARITY_R_score", transform=split_float_drop_na),
+    Column("VARITY_R_rankscore", transform=split_float_drop_na),
+    Column("VARITY_ER_score", transform=split_float_drop_na),
+    Column("VARITY_ER_rankscore", transform=split_float_drop_na),
+    Column("VARITY_R_LOO_score", dest="varity.r_loo.score", transform=split_float_drop_na),
+    Column("VARITY_R_LOO_rankscore", dest="varity.r_loo.rankscore", transform=split_float_drop_na),
+    Column("VARITY_ER_LOO_score", dest="varity.er_loo.score", transform=split_float_drop_na),
+    Column("VARITY_ER_LOO_rankscore", dest="varity.er_loo.rankscore", transform=split_float_drop_na),
+    Column("ESM1b_score", dest="esm1b.score", transform=split_float_drop_na),
+    Column("ESM1b_converted_rankscore", dest="esm1b.converted_rankscore", transform=split_float_drop_na),  # renamed from ESM1b_rankscore when dbNSFP 5.2 updated ESM1b scoring
+    Column("ESM1b_pred", dest="esm1b.pred", transform=split_str_drop_na),
+    # EVE retired by dbNSFP 5.0
+    Column("AlphaMissense_score", dest="alphamissense.score", transform=split_float_drop_na),
+    Column("AlphaMissense_rankscore", dest="alphamissense.rankscore", transform=split_float_drop_na),
+    Column("AlphaMissense_pred", dest="alphamissense.pred", transform=split_str_drop_na),
+    Column("PHACTboost_score", dest="phactboost.score", transform=split_float_drop_na),
+    Column("PHACTboost_rankscore", dest="phactboost.rankscore", transform=split_float_drop_na),
+    Column("MutFormer_score", dest="mutformer.score", transform=split_float_drop_na),
+    Column("MutFormer_rankscore", dest="mutformer.rankscore", transform=split_float_drop_na),
+    Column("MutScore_score", dest="mutscore.score", transform=split_float_drop_na),
+    Column("MutScore_rankscore", dest="mutscore.rankscore", transform=split_float_drop_na),
+    Column("popEVE_score", dest="popeve.score", transform=split_float_drop_na),  # new in 5.3.1a
+    Column("popEVE_pred", dest="popeve.pred", transform=split_str_drop_na),  # new in 5.3.1a
+    Column("popEVE_converted_rankscore", dest="popeve.converted_rankscore", transform=split_float_drop_na),  # new in 5.3.1a
+    Column("Aloft_Fraction_transcripts_affected", dest="protein.aloft.fraction_transcripts_affected", transform=split_str, tag=COLUMN_TAG.ALOFT_FRACTION_TRANSCRIPTS_AFFECTED),
+    Column("Aloft_prob_Tolerant", dest="protein.aloft.prob_tolerant", transform=split_str, tag=COLUMN_TAG.ALOFT_PROB_TOLERANT),
+    Column("Aloft_prob_Recessive", dest="protein.aloft.prob_recessive", transform=split_str, tag=COLUMN_TAG.ALOFT_PROB_RECESSIVE),
+    Column("Aloft_prob_Dominant", dest="protein.aloft.prob_dominant", transform=split_str, tag=COLUMN_TAG.ALOFT_PROB_DOMINANT),
+    Column("Aloft_pred", dest="protein.aloft.pred", transform=split_str, tag=COLUMN_TAG.ALOFT_PRED),
+    Column("Aloft_Confidence", dest="protein.aloft.confidence", transform=split_str, tag=COLUMN_TAG.ALOFT_CONFIDENCE),
+    Column("CADD_raw", dest="cadd.raw_score", transform=split_float_drop_na, assembly="hg38"),
+    Column("CADD_raw_rankscore", dest="cadd.raw_rankscore", transform=split_float_drop_na, assembly="hg38"),
+    Column("CADD_phred", transform=split_float_drop_na, assembly="hg38"),
+    Column("DANN_score", transform=split_float_drop_na),
+    Column("DANN_rankscore", transform=split_float_drop_na),
+    # fathmm-MKL retired by dbNSFP 5.0
+    Column("fathmm-XF_coding_score", dest="fathmm-xf.coding_score", transform=split_float_drop_na),
+    Column("fathmm-XF_coding_rankscore", dest="fathmm-xf.coding_rankscore", transform=split_float_drop_na),
+    Column("fathmm-XF_coding_pred", dest="fathmm-xf.coding_pred", transform=split_str_drop_na),
+    Column("Eigen-raw_coding", dest="eigen.raw_coding", transform=split_float_drop_na),
+    Column("Eigen-raw_coding_rankscore", dest="eigen.raw_coding_rankscore", transform=split_float_drop_na),
+    Column("Eigen-phred_coding", dest="eigen.phred_coding", transform=split_float_drop_na),
+    Column("Eigen-PC-raw_coding", dest="eigen-pc.raw_coding", transform=split_float_drop_na),
+    Column("Eigen-PC-raw_coding_rankscore", dest="eigen-pc.raw_coding_rankscore", transform=split_float_drop_na),
+    Column("Eigen-PC-phred_coding", dest="eigen-pc.phred_coding", transform=split_float_drop_na),
+    Column("GPN_MSA_score", dest="gpn_msa.score", transform=split_float_drop_na),  # added in dbNSFP 5.4
+    Column("GPN_MSA_converted_rankscore", dest="gpn_msa.converted_rankscore", transform=split_float_drop_na),  # ditto
+    Column("GPN_MSA_pred", dest="gpn_msa.pred", transform=split_str_drop_na),  # ditto
+    # GenoCanyon retired by dbNSFP 5.0
+    # fitCons (integrated, GM12878, H1-hESC, HUVEC) retired by dbNSFP 5.0
+    # LINSIGHT retired by dbNSFP 5.0
+    Column("GERP++_NR", transform=split_float_drop_na),
+    Column("GERP++_RS", transform=split_float_drop_na),
+    Column("GERP++_RS_rankscore", dest="gerp++.rs_rankscore", transform=split_float_drop_na),
+    Column("GERP_92_mammals", dest="gerp.92_mammals.score", transform=split_float_drop_na),  # added as GERP_91_mammals in dbNSFP 4.8; renamed to GERP_92_mammals in dbNSFP 5.3
+    Column("GERP_92_mammals_rankscore", dest="gerp.92_mammals.rankscore", transform=split_float_drop_na),  # ditto
+    Column("phyloP100way_vertebrate", dest="phylop.100way_vertebrate.score", transform=split_float_drop_na),
+    Column("phyloP100way_vertebrate_rankscore", dest="phylop.100way_vertebrate.rankscore", transform=split_float_drop_na),
+    Column("phyloP470way_mammalian", dest="phylop.470way_mammalian.score", transform=split_float_drop_na),
+    Column("phyloP470way_mammalian_rankscore", dest="phylop.470way_mammalian.rankscore", transform=split_float_drop_na),
+    Column("phyloP17way_primate", dest="phylop.17way_primate.score", transform=split_float_drop_na),
+    Column("phyloP17way_primate_rankscore", dest="phylop.17way_primate.rankscore", transform=split_float_drop_na),
+    Column("phastCons100way_vertebrate", dest="phastcons.100way_vertebrate.score", transform=split_float_drop_na),
+    Column("phastCons100way_vertebrate_rankscore", dest="phastcons.100way_vertebrate.rankscore", transform=split_float_drop_na),
+    Column("phastCons470way_mammalian", dest="phastcons.470way_mammalian.score", transform=split_float_drop_na),
+    Column("phastCons470way_mammalian_rankscore", dest="phastcons.470way_mammalian.rankscore", transform=split_float_drop_na),
+    Column("phastCons17way_primate", dest="phastcons.17way_primate.score", transform=split_float_drop_na),
+    Column("phastCons17way_primate_rankscore", dest="phastcons.17way_primate.rankscore", transform=split_float_drop_na),
+    # SiPhy retired by dbNSFP 5.0
+    Column("bStatistic", dest="bstatistic.score", transform=split_float_drop_na),
+    Column("bStatistic_converted_rankscore", dest="bstatistic.converted_rankscore", transform=split_float_drop_na),
+    Column("1000Gp3_AC", dest="1000gp3.ac", transform=int),
+    Column("1000Gp3_AF", dest="1000gp3.af", transform=float),
+    Column("1000Gp3_AFR_AC", dest="1000gp3.afr.ac", transform=int),
+    Column("1000Gp3_AFR_AF", dest="1000gp3.afr.af", transform=float),
+    Column("1000Gp3_EUR_AC", dest="1000gp3.eur.ac", transform=int),
+    Column("1000Gp3_EUR_AF", dest="1000gp3.eur.af", transform=float),
+    Column("1000Gp3_AMR_AC", dest="1000gp3.amr.ac", transform=int),
+    Column("1000Gp3_AMR_AF", dest="1000gp3.amr.af", transform=float),
+    Column("1000Gp3_EAS_AC", dest="1000gp3.eas.ac", transform=int),
+    Column("1000Gp3_EAS_AF", dest="1000gp3.eas.af", transform=float),
+    Column("1000Gp3_SAS_AC", dest="1000gp3.sas.ac", transform=int),
+    Column("1000Gp3_SAS_AF", dest="1000gp3.sas.af", transform=float),
+    # TWINSUK, ALSPAC, UK10K, ESP6500, ExAC, ExAC_nonTCGA, ExAC_nonpsych retired by dbNSFP 5.0
+    # TOPMed freeze8 (3 cols, added 5.0), gnomAD2.1.1 exomes controls/non_neuro/non_cancer (109 cols, added 5.0),
+    # gnomAD4.1 joint (45 cols, updated to v4.1 in 5.0), All of Us (28 cols, added 5.1), and RegeneronME (84 cols,
+    # added 5.1) are in the file but not parsed here (counted in VALID_COLUMN_NO only), consistent with gnomAD
+    # never being expanded into individual columns in earlier versions either (e.g. 4.8a)
+    Column("ALFA_European_AC", dest="alfa.european.ac", transform=int),
+    Column("ALFA_European_AN", dest="alfa.european.an", transform=int),
+    Column("ALFA_European_AF", dest="alfa.european.af", transform=float),
+    Column("ALFA_African_Others_AC", dest="alfa.african_others.ac", transform=int),
+    Column("ALFA_African_Others_AN", dest="alfa.african_others.an", transform=int),
+    Column("ALFA_African_Others_AF", dest="alfa.african_others.af", transform=float),
+    Column("ALFA_East_Asian_AC", dest="alfa.east_asian.ac", transform=int),
+    Column("ALFA_East_Asian_AN", dest="alfa.east_asian.an", transform=int),
+    Column("ALFA_East_Asian_AF", dest="alfa.east_asian.af", transform=float),
+    Column("ALFA_African_American_AC", dest="alfa.african_american.ac", transform=int),
+    Column("ALFA_African_American_AN", dest="alfa.african_american.an", transform=int),
+    Column("ALFA_African_American_AF", dest="alfa.african_american.af", transform=float),
+    Column("ALFA_Latin_American_1_AC", dest="alfa.latin_american_1.ac", transform=int),
+    Column("ALFA_Latin_American_1_AN", dest="alfa.latin_american_1.an", transform=int),
+    Column("ALFA_Latin_American_1_AF", dest="alfa.latin_american_1.af", transform=float),
+    Column("ALFA_Latin_American_2_AC", dest="alfa.latin_american_2.ac", transform=int),
+    Column("ALFA_Latin_American_2_AN", dest="alfa.latin_american_2.an", transform=int),
+    Column("ALFA_Latin_American_2_AF", dest="alfa.latin_american_2.af", transform=float),
+    Column("ALFA_Other_Asian_AC", dest="alfa.other_asian.ac", transform=int),
+    Column("ALFA_Other_Asian_AN", dest="alfa.other_asian.an", transform=int),
+    Column("ALFA_Other_Asian_AF", dest="alfa.other_asian.af", transform=float),
+    Column("ALFA_South_Asian_AC", dest="alfa.south_asian.ac", transform=int),
+    Column("ALFA_South_Asian_AN", dest="alfa.south_asian.an", transform=int),
+    Column("ALFA_South_Asian_AF", dest="alfa.south_asian.af", transform=float),
+    Column("ALFA_Other_AC", dest="alfa.other.ac", transform=int),
+    Column("ALFA_Other_AN", dest="alfa.other.an", transform=int),
+    Column("ALFA_Other_AF", dest="alfa.other.af", transform=float),
+    Column("ALFA_African_AC", dest="alfa.african.ac", transform=int),
+    Column("ALFA_African_AN", dest="alfa.african.an", transform=int),
+    Column("ALFA_African_AF", dest="alfa.african.af", transform=float),
+    Column("ALFA_Asian_AC", dest="alfa.asian.ac", transform=int),
+    Column("ALFA_Asian_AN", dest="alfa.asian.an", transform=int),
+    Column("ALFA_Asian_AF", dest="alfa.asian.af", transform=float),
+    Column("ALFA_Total_AC", dest="alfa.total.ac", transform=int),
+    Column("ALFA_Total_AN", dest="alfa.total.an", transform=int),
+    Column("ALFA_Total_AF", dest="alfa.total.af", transform=float),
+    # dbNSFP-computed POPMAX across all population databases (added in dbNSFP 5.1)
+    Column("dbNSFP_POPMAX_AF", dest="dbnsfp_popmax.af", transform=float),
+    Column("dbNSFP_POPMAX_AC", dest="dbnsfp_popmax.ac", transform=int),
+    Column("dbNSFP_POPMAX_POP", dest="dbnsfp_popmax.pop"),
+    # GTEx, eQTLGen, and Geuvadis eQTL columns retired by dbNSFP 5.0
+]
+
+HG19_COLUMNS = [c for c in COLUMNS if c.is_hg19()]
+HG38_COLUMNS = [c for c in COLUMNS if c.is_hg38()]
+PROTEIN_COLUMNS = [c for c in COLUMNS if c.dest.startswith(r"protein.")]
+
+# Currently not necessary to make assembly-specific tag-column maps.
+TAG_COLUMN_MAP = create_tag_column_map(COLUMNS)
+
+
+def verify_pos(row, pos_column: Column, na_values: set = NA_VALUES):
+    pos_value = row[pos_column.name]
+
+    if pos_value in na_values:
+        return False
+
+    return True
+
+
+def verify_hg19_row(row: dict, na_values: set = NA_VALUES):
+    pos_column = TAG_COLUMN_MAP[COLUMN_TAG.HG19_POS][0]
+    return verify_pos(row, pos_column=pos_column, na_values=na_values)
+
+
+def verify_hg38_row(row: dict, na_values: set = NA_VALUES):
+    pos_column = TAG_COLUMN_MAP[COLUMN_TAG.HG38_POS][0]
+    return verify_pos(row, pos_column=pos_column, na_values=na_values)
+
+
+def normalize_hg19_row(row: dict):
+    """
+    For unknown reasons, MutationTaster columns and Aloft columns have values ending in ";", which leads to an empty
+    string when splitting the value by ";". This function removes the trailing ";" in those values.
+    In dbNSFP 5.0, MutationTaster_AAE was removed and MutationTaster_trees_benign/deleterious were added (MutationTaster2021 model).
+    """
+    columns = [
+        # MutationTaster per-transcript columns
+        TAG_COLUMN_MAP[COLUMN_TAG.MUTATION_TASTER_MODEL][0],
+        TAG_COLUMN_MAP[COLUMN_TAG.MUTATION_TASTER_PRED][0],
+        TAG_COLUMN_MAP[COLUMN_TAG.MUTATION_TASTER_SCORE][0],
+        TAG_COLUMN_MAP[COLUMN_TAG.MUTATION_TASTER_TREES_BENIGN][0],
+        TAG_COLUMN_MAP[COLUMN_TAG.MUTATION_TASTER_TREES_DELETERIOUS][0],
+        # Aloft columns
+        TAG_COLUMN_MAP[COLUMN_TAG.ALOFT_FRACTION_TRANSCRIPTS_AFFECTED][0],
+        TAG_COLUMN_MAP[COLUMN_TAG.ALOFT_PROB_TOLERANT][0],
+        TAG_COLUMN_MAP[COLUMN_TAG.ALOFT_PROB_RECESSIVE][0],
+        TAG_COLUMN_MAP[COLUMN_TAG.ALOFT_PROB_DOMINANT][0],
+        TAG_COLUMN_MAP[COLUMN_TAG.ALOFT_PRED][0],
+        TAG_COLUMN_MAP[COLUMN_TAG.ALOFT_CONFIDENCE][0]
+    ]
+
+    for c in columns:
+        if row[c.name] and row[c.name][-1] == ";":
+            row[c.name] = row[c.name][:-1]
+
+    return row
+
+
+def normalize_hg38_row(row: dict):
+    return normalize_hg19_row(row)
+
+
+def prune_mutation_taster(raw_doc: dict, model_column: Column, pred_column: Column, score_column: Column,
+                           trees_benign_column: Column, trees_deleterious_column: Column, na_values: set = NA_VALUES):
+    """
+    Map each MutationTaster model, pred, score, trees_benign, and trees_deleterious value from the raw document
+    into a dictionary, and assign all such dictionaries to the raw document's "mutationtaster.analysis" field.
+    In dbNSFP 5.0, MutationTaster_AAE was removed and two new tree count columns were added (MutationTaster2021 model).
+
+    E.g. with the following input value:
+
+        row["mutationtaster.model"] = "complex_aae;complex_aae;simple_aae"
+        row["mutationtaster.pred"] = "D;D;N"
+        row["mutationtaster.score"] = "1;1;1"
+        row["mutationtaster.trees_benign"] = "0;0;45"
+        row["mutationtaster.trees_deleterious"] = "100;100;55"
+
+    raw_doc will be assigned as:
+
+         row["mutationtaster.analysis"] = [
+            {'model': 'complex_aae', 'pred': 'D', 'score': 1, 'trees_benign': 0, 'trees_deleterious': 100},
+            {'model': 'complex_aae', 'pred': 'D', 'score': 1, 'trees_benign': 0, 'trees_deleterious': 100},
+            {'model': 'simple_aae', 'pred': 'N', 'score': 1, 'trees_benign': 45, 'trees_deleterious': 55}
+        ]
+    """
+    required_columns = [model_column, pred_column, score_column, trees_benign_column, trees_deleterious_column]
+    if all(c.dest in raw_doc for c in required_columns):
+        model_value = raw_doc[model_column.dest]
+        pred_value = raw_doc[pred_column.dest]
+        score_value = raw_doc[score_column.dest]
+        trees_benign_value = raw_doc[trees_benign_column.dest]
+        trees_deleterious_value = raw_doc[trees_deleterious_column.dest]
+
+        analysis_values = split_zip(
+            [model_value, pred_value, score_value, trees_benign_value, trees_deleterious_value],
+            sep=r";",
+            na_values=na_values
+        )
+        analysis_result = [
+            {
+                "model": model,
+                "pred": pred,
+                "score": float(score) if score is not None else None,
+                "trees_benign": int(trees_benign) if trees_benign is not None else None,
+                "trees_deleterious": int(trees_deleterious) if trees_deleterious is not None else None
+            }
+            for (model, pred, score, trees_benign, trees_deleterious) in analysis_values
+        ]
+        # Remove None values from each analysis entry
+        analysis_result = [{k: v for k, v in entry.items() if v is not None} for entry in analysis_result]
+        analysis_result = _check_length(analysis_result)
+        if analysis_result is not None:
+            raw_doc["mutationtaster.analysis"] = analysis_result
+
+        for c in required_columns:
+            del raw_doc[c.dest]
+
+        # note that raw_doc["mutationtaster.rankscore"] is kept as-is
+
+    return raw_doc
+
+
+def prune_protein(raw_doc: set, protein_columns: list[Column]):
+    protein_fields = {c.dest: raw_doc[c.dest] for c in protein_columns}
+
+    """
+    Convert protein fields (as a dictionary of lists) to a list of dictionaries. E.g.
+
+        protein_field = {
+            'protein.transcriptid': ['ENST00000624406', 'ENST00000398168'],
+            'protein.proteinid': ['ENSP00000485669', 'ENSP00000381234']
+        }
+
+    will be converted to
+
+        protein_result = [
+            {'protein.transcriptid': 'ENST00000624406', 'protein.proteinid': 'ENSP00000485669'},
+            {'protein.transcriptid': 'ENST00000398168', 'protein.proteinid': 'ENSP00000381234'}
+        ]
+    """
+    protein_result = []
+    protein_keys = protein_fields.keys()
+    for protein_values in zip(*protein_fields.values()):
+        elem = dict((key, value) for key, value in zip(protein_keys, protein_values) if value is not None)
+        elem = parse_dot_fields(elem)["protein"]
+        protein_result.append(elem)
+    # We keep protein_result as a list for easier merging
+    raw_doc["protein"] = protein_result
+
+    for c in protein_columns:
+        del raw_doc[c.dest]
+
+    return raw_doc
+
+
+def prune_hg19_doc(doc: dict, na_values: set = NA_VALUES):
+    protein_columns = [c for c in PROTEIN_COLUMNS if c.dest in doc]
+    doc = prune_protein(doc, protein_columns=protein_columns)
+
+    mutation_taster_model_column = TAG_COLUMN_MAP[COLUMN_TAG.MUTATION_TASTER_MODEL][0]
+    mutation_taster_pred_column = TAG_COLUMN_MAP[COLUMN_TAG.MUTATION_TASTER_PRED][0]
+    mutation_taster_score_column = TAG_COLUMN_MAP[COLUMN_TAG.MUTATION_TASTER_SCORE][0]
+    mutation_taster_trees_benign_column = TAG_COLUMN_MAP[COLUMN_TAG.MUTATION_TASTER_TREES_BENIGN][0]
+    mutation_taster_trees_deleterious_column = TAG_COLUMN_MAP[COLUMN_TAG.MUTATION_TASTER_TREES_DELETERIOUS][0]
+    doc = prune_mutation_taster(
+        doc,
+        model_column=mutation_taster_model_column,
+        pred_column=mutation_taster_pred_column,
+        score_column=mutation_taster_score_column,
+        trees_benign_column=mutation_taster_trees_benign_column,
+        trees_deleterious_column=mutation_taster_trees_deleterious_column,
+        na_values=na_values
+    )
+
+    return doc
+
+
+def prune_hg38_doc(doc: dict, na_values: set = NA_VALUES):
+    return prune_hg19_doc(doc, na_values=na_values)
+
+
+def construct_raw_doc(row: dict, columns: list, na_values: set = NA_VALUES):
+    """
+    Construct a raw dbnsfp doc from a dict-like row read from the csv file.
+    "Raw" means 1) the doc may contain dot fields that are not parsed, and 2) some values in the doc need further treatment/processing.
+
+    Args:
+        row: a dict representing a csv row's content
+        columns: a list of Column object indicating how to construct each column
+        na_values: a set of values seen as NA
+    Returns:
+        a dict representing the doc's json object
+    """
+    result = dict()
+
+    for column in columns:
+        value = row[column.name]
+        if value in na_values:
+            continue
+
+        value = column.transform(value)
+        if value is None:
+            continue
+
+        result[column.dest] = value
+
+    return result
+
+
+def construct_hg19_raw_doc(row: dict, na_values: set = NA_VALUES):
+    return construct_raw_doc(row, columns=HG19_COLUMNS, na_values=na_values)
+
+
+def construct_hg38_raw_doc(row: dict, na_values: set = NA_VALUES):
+    return construct_raw_doc(row, columns=HG38_COLUMNS, na_values=na_values)
+
+
+def make_hgvs_id(doc: dict, chrom_column: Column, pos_column: Column, ref_column: Column, alt_column: Column):
+    chrom_value = doc[chrom_column.dest]
+    pos_value = doc[pos_column.dest]["start"]  # see make_zero_based()
+    ref_value = doc[ref_column.dest]
+    alt_value = doc[alt_column.dest]
+
+    hgvs_id = "chr%s:g.%d%s>%s" % (chrom_value, pos_value, ref_value, alt_value)
+    return hgvs_id
+
+
+def make_hg19_hgvs_id(doc: dict):
+    chrom_column = TAG_COLUMN_MAP[COLUMN_TAG.HG19_CHROM][0]
+    pos_column = TAG_COLUMN_MAP[COLUMN_TAG.HG19_POS][0]
+    ref_column = TAG_COLUMN_MAP[COLUMN_TAG.REF_ALLELE][0]
+    alt_column = TAG_COLUMN_MAP[COLUMN_TAG.ALT_ALLELE][0]
+
+    return make_hgvs_id(doc, chrom_column=chrom_column, pos_column=pos_column, ref_column=ref_column, alt_column=alt_column)
+
+
+def make_hg38_hgvs_id(doc: dict):
+    chrom_column = TAG_COLUMN_MAP[COLUMN_TAG.HG38_CHROM][0]
+    pos_column = TAG_COLUMN_MAP[COLUMN_TAG.HG38_POS][0]
+    ref_column = TAG_COLUMN_MAP[COLUMN_TAG.REF_ALLELE][0]
+    alt_column = TAG_COLUMN_MAP[COLUMN_TAG.ALT_ALLELE][0]
+
+    return make_hgvs_id(doc, chrom_column=chrom_column, pos_column=pos_column, ref_column=ref_column, alt_column=alt_column)
+
+
+def construct_hg19_doc(row: dict, na_values: set = NA_VALUES):
+    verified = verify_hg19_row(row, na_values=na_values)
+    if not verified:
+        return None
+
+    row = normalize_hg19_row(row)
+    raw_doc = construct_hg19_raw_doc(row, na_values=na_values)
+    raw_doc = prune_hg19_doc(raw_doc, na_values=na_values)
+    hgvs_id = make_hg19_hgvs_id(raw_doc)
+
+    doc = {
+        "_id": hgvs_id,
+        "dbnsfp": parse_dot_fields(raw_doc)  # convert dot-fields into nested dictionaries
+    }
+    return doc
+
+
+def construct_hg38_doc(row: dict, na_values: set = NA_VALUES):
+    verified = verify_hg38_row(row, na_values=na_values)
+    if not verified:
+        return None
+
+    row = normalize_hg38_row(row)
+    raw_doc = construct_hg38_raw_doc(row, na_values=na_values)
+    raw_doc = prune_hg38_doc(raw_doc, na_values=na_values)
+    hgvs_id = make_hg38_hgvs_id(raw_doc)
+
+    doc = {
+        "_id": hgvs_id,
+        "dbnsfp": parse_dot_fields(raw_doc)  # convert dot-fields into nested dictionaries
+    }
+    return doc
+
+
+def load_file(path: str, assembly: str):
+    file = anyfile(path)
+    file_reader = csv.DictReader(file, delimiter="\t")
+
+    num_columns = len(file_reader.fieldnames)
+    if VALID_COLUMN_NO is not None:
+        assert num_columns == VALID_COLUMN_NO, "Expecting %s columns, but got %s" % (VALID_COLUMN_NO, num_columns)
+
+    _construct_doc = None
+    match assembly:
+        case "hg19":
+            _construct_doc = construct_hg19_doc
+        case "hg38":
+            _construct_doc = construct_hg38_doc
+        case _:
+            raise ValueError(f"Cannot recognize assembly. Accept 'hg19' or 'hg38', got '{assembly}'.")
+
+    last_doc = None
+    for row in file_reader:
+        curr_doc = _construct_doc(row, na_values=NA_VALUES)
+
+        if curr_doc is None:
+            continue
+
+        if last_doc is not None:
+            if curr_doc["_id"] == last_doc["_id"]:
+                last_protein_field = last_doc["dbnsfp"]["protein"]
+                curr_protein_field = curr_doc["dbnsfp"]["protein"]
+
+                # We guarantee that the protein field is always a list at this moment. See prune_protein()
+                last_protein_field.extend(curr_protein_field)
+
+                last_doc["dbnsfp"]["protein"] = last_protein_field
+                continue
+            else:
+                if len(last_doc["dbnsfp"]["protein"]) == 1:
+                    last_doc["dbnsfp"]["protein"] = last_doc["dbnsfp"]["protein"][0]
+                yield last_doc
+
+        last_doc = curr_doc
+
+    # yield the very last doc
+    if last_doc:
+        if len(last_doc["dbnsfp"]["protein"]) == 1:
+            last_doc["dbnsfp"]["protein"] = last_doc["dbnsfp"]["protein"][0]
+        yield last_doc
+
+    file.close()

--- a/src/hub/dataload/sources/dbnsfp/dbnsfp_upload.py
+++ b/src/hub/dataload/sources/dbnsfp/dbnsfp_upload.py
@@ -1,10 +1,10 @@
 import os
 import glob
 
-from .dbnsfp_mapping_48a_v1 import mapping as mapping_v1
-from .dbnsfp_parser_48a_v1 import load_file as load_file_v1
-from .dbnsfp_mapping_48a_v2 import mapping as mapping_v2
-from .dbnsfp_parser_48a_v2 import load_file as load_file_v2
+from .dbnsfp_mapping_54a_v1 import mapping as mapping_v1
+from .dbnsfp_parser_54a_v1 import load_file as load_file_v1
+from .dbnsfp_mapping_54a_v2 import mapping as mapping_v2
+from .dbnsfp_parser_54a_v2 import load_file as load_file_v2
 
 import biothings.hub.dataload.uploader as uploader
 from hub.dataload.uploader import SnpeffPostUpdateUploader
@@ -12,9 +12,10 @@ from hub.dataload.storage import MyVariantIgnoreDuplicatedStorage
 
 
 SRC_META = {
-    "url": "https://sites.google.com/site/jpopgen/dbNSFP",
-    "license_url": "https://sites.google.com/site/jpopgen/dbNSFP",
-    "license_url_short": "http://bit.ly/2VLnQBz"
+    # sites.google.com/site/jpopgen/dbNSFP is the pre-5.x legacy site (tops out at 4.9a);
+    # dbnsfp.org is current as of 5.x. See dbnsfp_dump.py / README.md for the download flow.
+    "url": "https://www.dbnsfp.org",
+    "license_url": "https://creativecommons.org/licenses/by-nc-nd/4.0/",
 }
 
 

--- a/src/hub/dataload/sources/dbsnp/dbsnp_dump.py
+++ b/src/hub/dataload/sources/dbsnp/dbsnp_dump.py
@@ -31,6 +31,24 @@ class DBSNPDumper(FTPDumper):
 
     SCHEDULE = "0 9 * * *"
 
+    def __getstate__(self):
+        # Every file dispatch pickles this whole instance to ship self.download()
+        # to a worker process (job_manager.defer_to_process). self.src_dump is a
+        # live pymongo Collection (biothings sets it in BaseDumper for recording
+        # dump status) whose underlying client can pick up a threading.Lock once
+        # anything in the hub touches Mongo concurrently with this dump -- and
+        # locks can never be pickled. download() doesn't use src_dump (or client,
+        # which is already cleared between attempts), so drop both here instead of
+        # having unrelated hub activity intermittently break dispatching this
+        # dumper's download jobs.
+        state = self.__dict__.copy()
+        state["src_dump"] = None
+        state["client"] = None
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+
     def set_release(self):
         try:
             self.client.cwd(self.__class__.VERSIONS_DIR)

--- a/src/hub/dataload/sources/dbsnp/dbsnp_dump.py
+++ b/src/hub/dataload/sources/dbsnp/dbsnp_dump.py
@@ -31,24 +31,6 @@ class DBSNPDumper(FTPDumper):
 
     SCHEDULE = "0 9 * * *"
 
-    def __getstate__(self):
-        # Every file dispatch pickles this whole instance to ship self.download()
-        # to a worker process (job_manager.defer_to_process). self.src_dump is a
-        # live pymongo Collection (biothings sets it in BaseDumper for recording
-        # dump status) whose underlying client can pick up a threading.Lock once
-        # anything in the hub touches Mongo concurrently with this dump -- and
-        # locks can never be pickled. download() doesn't use src_dump (or client,
-        # which is already cleared between attempts), so drop both here instead of
-        # having unrelated hub activity intermittently break dispatching this
-        # dumper's download jobs.
-        state = self.__dict__.copy()
-        state["src_dump"] = None
-        state["client"] = None
-        return state
-
-    def __setstate__(self, state):
-        self.__dict__.update(state)
-
     def set_release(self):
         try:
             self.client.cwd(self.__class__.VERSIONS_DIR)
@@ -67,8 +49,8 @@ class DBSNPDumper(FTPDumper):
         try:
             self.client.retrbinary("RETR %s" % self.__class__.CHECKSUMS_FILE, buf.write)
         except Exception as e:
-            self.logger.warning("Couldn't fetch '%s', downloads won't be checksum-verified: %s" %
-                                 (self.__class__.CHECKSUMS_FILE, e))
+            logging.warning("Couldn't fetch '%s', downloads won't be checksum-verified: %s" %
+                             (self.__class__.CHECKSUMS_FILE, e))
             return {}
         expected_md5s = {}
         for line in buf.getvalue().decode().splitlines():
@@ -138,6 +120,18 @@ class DBSNPDumper(FTPDumper):
                 self.release_client()
 
     def post_download(self, remotefile, localfile):
+        # NOTE: deliberately uses the plain module-level `logging` here, not
+        # `self.logger`. self.logger/self.src_dump are lazy properties backed by
+        # self._state (see biothings' BaseDumper); do_dump() calls self.unprepare()
+        # exactly once, before the whole per-file dispatch loop, to null out
+        # self._state so `self` can be pickled to ship download() to a worker
+        # process. post_download() runs in the main process, interleaved with
+        # later dispatches in that same loop -- merely *reading* self.logger here
+        # would lazily reconnect it (BaseDumper.logger's getter calls
+        # self.prepare(), which also reconnects self.src_dump, a live pymongo
+        # connection holding a threading.Lock that can never be pickled), breaking
+        # pickling for every dispatch that follows. Using the plain logger avoids
+        # touching that property entirely.
         expected_md5 = getattr(self, "_expected_md5s", {}).get(remotefile)
         if not expected_md5:
             # CHECKSUMS couldn't be fetched, or has no entry for this file
@@ -152,5 +146,5 @@ class DBSNPDumper(FTPDumper):
             raise ValueError(
                 "Checksum mismatch for '%s': expected %s, got %s (file removed, will retry on next run)" %
                 (remotefile, expected_md5, actual_md5))
-        self.logger.info("Checksum verified for '%s'" % remotefile)
+        logging.info("Checksum verified for '%s'" % remotefile)
 

--- a/src/hub/dataload/sources/dbsnp/dbsnp_dump.py
+++ b/src/hub/dataload/sources/dbsnp/dbsnp_dump.py
@@ -1,3 +1,5 @@
+import hashlib
+import io
 import os
 import os.path
 import sys, re
@@ -17,7 +19,14 @@ class DBSNPDumper(FTPDumper):
     CWD_DIR = '/snp/latest_release/JSON'
     VERSIONS_DIR = '/snp/archive'
     FILE_RE = 'refsnp-chr*.json.bz2'
+    CHECKSUMS_FILE = 'CHECKSUMS'
     MAX_PARALLEL_DUMP = 1   # reduced from 10 to 1 to prevent download timeout
+    # these files are 1-38GB each and can take hours to download; NCBI's FTP server
+    # can go quiet for several minutes at a time during such long transfers, and the
+    # 10-minute default is aggressive enough to kill an otherwise-healthy download.
+    # Since retrbinary() has no resume support, any timeout means restarting that
+    # file from scratch, so it's worth tolerating longer stalls here.
+    FTP_TIMEOUT = 30 * 60.0
 
     SCHEDULE = "0 9 * * *"
 
@@ -30,9 +39,30 @@ class DBSNPDumper(FTPDumper):
         finally:
             self.client.cwd(self.__class__.CWD_DIR)
 
+    def _fetch_checksums(self):
+        """Fetch and parse the remote CHECKSUMS file (md5sum-style lines:
+        '<md5>  <filename>') so each download can be verified in post_download().
+        Returns {} (skipping verification) if it can't be fetched, rather than
+        failing the whole dump over a 1.7KB file."""
+        buf = io.BytesIO()
+        try:
+            self.client.retrbinary("RETR %s" % self.__class__.CHECKSUMS_FILE, buf.write)
+        except Exception as e:
+            self.logger.warning("Couldn't fetch '%s', downloads won't be checksum-verified: %s" %
+                                 (self.__class__.CHECKSUMS_FILE, e))
+            return {}
+        expected_md5s = {}
+        for line in buf.getvalue().decode().splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            md5sum, filename = line.split(None, 1)
+            expected_md5s[filename] = md5sum
+        return expected_md5s
 
     def create_todump_list(self, force=False):
         self.set_release()
+        self._expected_md5s = self._fetch_checksums()
         filenames = [fn for fn in self.client.nlst(self.__class__.FILE_RE)]
         assert len(filenames) == 25, "Expected 25 files, got %s" % len(filenames)
         for filename in filenames:
@@ -44,4 +74,21 @@ class DBSNPDumper(FTPDumper):
                 current_localfile = new_localfile
             if force or not os.path.exists(current_localfile) or self.remote_is_better(filename, current_localfile):
                 self.to_dump.append({"remote":filename, "local":new_localfile})
+
+    def post_download(self, remotefile, localfile):
+        expected_md5 = getattr(self, "_expected_md5s", {}).get(remotefile)
+        if not expected_md5:
+            # CHECKSUMS couldn't be fetched, or has no entry for this file
+            return
+        actual_md5 = hashlib.md5()
+        with open(localfile, "rb") as f:
+            for chunk in iter(lambda: f.read(64 * 1024 * 1024), b""):
+                actual_md5.update(chunk)
+        actual_md5 = actual_md5.hexdigest()
+        if actual_md5 != expected_md5:
+            os.remove(localfile)
+            raise ValueError(
+                "Checksum mismatch for '%s': expected %s, got %s (file removed, will retry on next run)" %
+                (remotefile, expected_md5, actual_md5))
+        self.logger.info("Checksum verified for '%s'" % remotefile)
 

--- a/src/hub/dataload/sources/dbsnp/dbsnp_dump.py
+++ b/src/hub/dataload/sources/dbsnp/dbsnp_dump.py
@@ -24,9 +24,10 @@ class DBSNPDumper(FTPDumper):
     # these files are 1-38GB each and can take hours to download; NCBI's FTP server
     # can go quiet for several minutes at a time during such long transfers, and the
     # 10-minute default is aggressive enough to kill an otherwise-healthy download.
-    # Since retrbinary() has no resume support, any timeout means restarting that
-    # file from scratch, so it's worth tolerating longer stalls here.
     FTP_TIMEOUT = 30 * 60.0
+    # even 30 minutes isn't always enough on a bad link, so on top of that, resume
+    # (rather than restart from scratch) up to this many times per file.
+    MAX_DOWNLOAD_ATTEMPTS = 8
 
     SCHEDULE = "0 9 * * *"
 
@@ -74,6 +75,49 @@ class DBSNPDumper(FTPDumper):
                 current_localfile = new_localfile
             if force or not os.path.exists(current_localfile) or self.remote_is_better(filename, current_localfile):
                 self.to_dump.append({"remote":filename, "local":new_localfile})
+
+    def download(self, remotefile, localfile):
+        self.prepare_local_folders(localfile)
+        block_size = self._get_optimal_buffer_size()
+        last_exc = None
+        try:
+            for attempt in range(1, self.__class__.MAX_DOWNLOAD_ATTEMPTS + 1):
+                if self.need_prepare():
+                    self.prepare_client()
+                offset = os.path.getsize(localfile) if os.path.exists(localfile) else 0
+                mode = "ab" if offset else "wb"
+                self.logger.debug("Downloading '%s' as '%s' (attempt %d/%d, resuming from byte %d)" %
+                                   (remotefile, localfile, attempt, self.__class__.MAX_DOWNLOAD_ATTEMPTS, offset))
+                try:
+                    with open(localfile, mode) as out_f:
+                        # retrbinary()'s "rest" arg sends a REST command so the transfer
+                        # picks up where the previous attempt left off, instead of
+                        # restarting this multi-GB file from byte 0 on every timeout.
+                        self.client.retrbinary(cmd="RETR %s" % remotefile, callback=out_f.write,
+                                                blocksize=block_size, rest=str(offset) if offset else None)
+                    # set the mtime to match remote ftp server
+                    response = self.client.sendcmd("MDTM " + remotefile)
+                    code, lastmodified = response.split()
+                    lastmodified = time.mktime(datetime.strptime(lastmodified, "%Y%m%d%H%M%S").timetuple())
+                    os.utime(localfile, (lastmodified, lastmodified))
+                    return code
+                except Exception as e:
+                    last_exc = e
+                    new_size = os.path.getsize(localfile) if os.path.exists(localfile) else 0
+                    self.logger.warning(
+                        "Attempt %d/%d downloading '%s' failed at byte %d, will resume: %s" %
+                        (attempt, self.__class__.MAX_DOWNLOAD_ATTEMPTS, remotefile, new_size, e))
+                    # connection is likely broken, force a fresh one on the next attempt
+                    if self.client:
+                        self.release_client()
+                    if attempt < self.__class__.MAX_DOWNLOAD_ATTEMPTS:
+                        time.sleep(min(60, 5 * attempt))
+            self.logger.error("Giving up on '%s' after %d attempts: %s" %
+                               (remotefile, self.__class__.MAX_DOWNLOAD_ATTEMPTS, last_exc))
+            raise last_exc
+        finally:
+            if self.client:
+                self.release_client()
 
     def post_download(self, remotefile, localfile):
         expected_md5 = getattr(self, "_expected_md5s", {}).get(remotefile)

--- a/src/hub/dataload/sources/snpeff/snpeff_parser.py
+++ b/src/hub/dataload/sources/snpeff/snpeff_parser.py
@@ -6,6 +6,7 @@ import subprocess
 from biothings import config
 from biothings.utils.common import loadobj
 from biothings.utils.dataload import unlist, dict_sweep
+from config import MAX_REF_ALT_LEN
 from utils.hgvs import prune_redundant_seq
 from utils.validate import bit_to_nuc
 
@@ -85,6 +86,12 @@ class VCFConstruct(object):
             end = int(hgvs[1])
         else:
             end = int(hgvs[2])
+        if end - pos > MAX_REF_ALT_LEN:
+            # Some ClinVar records (e.g. large TTN deletions) span tens of kb. Building
+            # and sending such a huge REF allele crashes the snpEff subprocess instead of
+            # just failing to annotate, so skip these before doing the expensive lookup.
+            self.logger.warning("Skipping deletion HGVS %s: interval too large (%d bp) for snpEff annotation" % (repr(hgvs), end - pos))
+            return None
         chr_bit = self._chr_data[str(chrom)]
         ref = ''
         for i in range(pos, end+1):
@@ -126,6 +133,11 @@ class VCFConstruct(object):
         chrom = hgvs[0]
         pos = int(hgvs[1])
         end = int(hgvs[2])
+        if end - pos > MAX_REF_ALT_LEN:
+            # Same rationale as del_vcf_constructor: don't hand snpEff a REF allele
+            # spanning tens of kb, it crashes the subprocess instead of just skipping it.
+            self.logger.warning("Skipping delins HGVS %s: interval too large (%d bp) for snpEff annotation" % (repr(hgvs), end - pos))
+            return None
         chr_bit = self._chr_data[str(chrom)]
         ref = ''
         for i in range(pos, end+1):

--- a/src/hub/dataload/sources/uniprot/uniprot_dump.py
+++ b/src/hub/dataload/sources/uniprot/uniprot_dump.py
@@ -1,0 +1,36 @@
+import os
+
+import biothings, config
+biothings.config_for_app(config)
+
+from config import DATA_ARCHIVE_ROOT
+from biothings.hub.dataload.dumper import LastModifiedHTTPDumper
+
+
+class UniprotDumper(LastModifiedHTTPDumper):
+    """
+    Downloads the UniProtKB "current_release" variant files backing the
+    'uniprot' myvariant.info source (see UniprotUploader.get_mapping()):
+
+      - humsavar.txt: manually curated human missense variants (Swiss-Prot AC,
+        FTId, ACMG/AMP-style variant category, disease name), used to populate
+        the 'humsavar' sub-fields.
+      - homo_sapiens_variation.txt.gz: protein-altering variants imported from
+        Ensembl Variation/dbSNP/ClinVar/COSMIC, one row per variant per
+        transcript/phenotype. Used to populate 'source_db_id',
+        'clinical_significance', 'phenotype_disease' and
+        'phenotype_disease_source'.
+
+    Both files live at a stable URL that UniProt updates in place with each
+    release, so there's no version-specific filename to look for; the release
+    is tracked from the HTTP Last-Modified header instead.
+    """
+
+    SRC_NAME = "uniprot"
+    SRC_ROOT_FOLDER = os.path.join(DATA_ARCHIVE_ROOT, SRC_NAME)
+    SRC_URLS = [
+        "https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/variants/humsavar.txt",
+        "https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/variants/homo_sapiens_variation.txt.gz",
+    ]
+
+    SCHEDULE = "0 9 * * *"

--- a/src/hub/dataload/sources/uniprot/uniprot_parser.py
+++ b/src/hub/dataload/sources/uniprot/uniprot_parser.py
@@ -1,54 +1,95 @@
 """
-Loads humsavar.txt and homo_sapiens_variation.txt.gz as-is into 'uniprot'
-documents: one document per line in either file, verbatim. There is no
-deduplication, no merging of rows, and no correlation between the two files
--- each line becomes its own independent document, identified by a random id
-(not a computed/genomic one).
+Parses the two UniProtKB variant files (see uniprot_dump.py for how they're
+fetched) into 'uniprot' myvariant.info documents, loading ALL data from
+BOTH files and connecting records that relate to each other:
 
-Every document needs an explicit "_id" here, even though its value carries
-no meaning: this project's MyVariantBasicStorage (see
-hub/dataload/storage.py) always looks at doc["_id"] before insert, to check
-whether it's a genomic HGVS id long enough to need shortening. Leaving "_id"
-unset (to let MongoDB assign one on insert) makes that lookup raise
-AssertionError for every document, since it runs before the insert ever
-happens.
+  - homo_sapiens_variation.txt.gz: bulk protein-altering variant index (59M+
+    rows, mostly dbSNP/ClinVar-sourced). Every unique genomic coordinate
+    found here becomes one output document, populated with whatever
+    'source_db_id' / 'clinical_significance' / 'phenotype_disease' /
+    'phenotype_disease_source' values UniProt reports at that position
+    (every source sharing the coordinate -- rs, RCV, or anything else, not
+    just one).
+  - humsavar.txt: manually curated missense variants, ~85K records. It has
+    no genomic coordinate of its own (only a dbSNP id). When a record's
+    dbSNP id matches one of a coordinate's source_db_id values, its fields
+    are attached to that coordinate's document -- so some documents end up
+    with data from both files. When a record's dbSNP id doesn't match
+    anything in the variation file (or it has no dbSNP id at all -- about
+    17% of humsavar.txt), it still becomes its own standalone document
+    (humsavar-only, no genomic coordinate to derive a real _id from, so it
+    gets a random one instead) rather than being dropped: every humsavar
+    record ends up as a document somewhere, matched or not.
 
-Column names already used elsewhere in this mapping are reused
-(source_db_id, clinical_significance, phenotype_disease,
-phenotype_disease_source, swiss_prot_ac, ftid, type_of_variant,
-disease_name); every other column is stored under a name derived from its
-own header (see _HUMSAVAR_FIELDS / _VARIATION_FIELDS below).
+Variation-file rows whose 'Chromosome Coordinate' isn't a recognized GRCh38
+chromosome accession are skipped: without a genomic coordinate there is no
+way to build the 'chrN:g.posREF>ALT' _id myvariant.info uses elsewhere.
 """
 import glob
 import gzip
+import logging
 import os
 import uuid
+
+from biothings.utils.dataload import unlist
 
 HUMSAVAR_FILE = "humsavar.txt"
 VARIATION_FILE_GLOB = "homo_sapiens_variation.txt.gz"
 
-# humsavar.txt columns, in file order: Main gene name | Swiss-Prot AC | FTId |
-# AA change | Variant category | dbSNP | Disease name
-_HUMSAVAR_FIELDS = [
-    "gene_name", "swiss_prot_ac", "ftid", "aa_change", "type_of_variant", "dbsnp", "disease_name",
-]
+# GRCh38 RefSeq chromosome accession prefix (before the version suffix) ->
+# myvariant.info chromosome name.
+_NC_TO_CHROM = {("NC_%06d" % i): str(i) for i in range(1, 23)}
+_NC_TO_CHROM["NC_000023"] = "X"
+_NC_TO_CHROM["NC_000024"] = "Y"
+_NC_TO_CHROM["NC_012920"] = "MT"
 
-# homo_sapiens_variation.txt.gz columns, in file order: Gene Name | AC |
-# Variant AA Change | Source DB ID | Consequence Type | Clinical
-# Significance | Phenotype/Disease | Phenotype/Disease Source | Cytogenetic
-# Band | Chromosome Coordinate | Ensembl gene ID | Ensembl transcript ID |
-# Ensembl translation ID | Evidence
-_VARIATION_FIELDS = [
-    "gene_name", "swiss_prot_ac", "aa_change", "source_db_id", "consequence_type",
-    "clinical_significance", "phenotype_disease", "phenotype_disease_source",
-    "cytogenetic_band", "chromosome_coordinate", "ensembl_gene_id",
-    "ensembl_transcript_id", "ensembl_translation_id", "evidence",
-]
+
+def nc_coordinate_to_hgvs_id(coordinate):
+    """
+    Convert a UniProt 'Chromosome Coordinate' value, e.g.
+    'NC_000017.11:g.30178149A>G', into a myvariant.info _id, e.g.
+    'chr17:g.30178149A>G'. Returns None if the accession isn't a recognized
+    GRCh38 chromosome accession.
+    """
+    accession, sep, rest = coordinate.partition(":")
+    if not sep:
+        return None
+    prefix = accession.split(".")[0]
+    chrom = _NC_TO_CHROM.get(prefix)
+    if not chrom:
+        return None
+    return "chr%s:%s" % (chrom, rest)
+
+
+def _parse_humsavar_line(line):
+    """
+    Parse one humsavar.txt data line (fixed-width/whitespace separated, NOT
+    tab-delimited):
+        A1BG        P04217     VAR_018369  p.His52Arg     LB/B     rs893184       -
+    Columns: gene name, Swiss-Prot AC, FTId, AA change, variant category,
+    dbSNP id, disease name (free text, may itself contain spaces).
+    Returns None for blank/malformed lines.
+    """
+    line = line.rstrip("\n")
+    if not line.strip():
+        return None
+    parts = line.split(None, 6)
+    if len(parts) < 6:
+        return None
+    _gene_name, swiss_prot_ac, ftid, _aa_change, type_of_variant, dbsnp_id = parts[:6]
+    disease_name = parts[6] if len(parts) == 7 else "-"
+    return {
+        "swiss_prot_ac": swiss_prot_ac,
+        "ftid": ftid,
+        "type_of_variant": type_of_variant,
+        "dbsnp_id": None if dbsnp_id == "-" else dbsnp_id,
+        "disease_name": None if disease_name == "-" else disease_name,
+    }
 
 
 def parse_humsavar(lines):
-    """Yield one {"uniprot": {...}} document per humsavar.txt data line,
-    verbatim, skipping the multi-line preamble/header."""
+    """Parse humsavar.txt content (an iterable of lines), skipping the
+    multi-line preamble/header. Yields one dict per data row."""
     started = False
     for line in lines:
         if line.startswith("_________"):
@@ -56,20 +97,35 @@ def parse_humsavar(lines):
             continue
         if not started:
             continue
-        line = line.rstrip("\n")
-        if not line.strip():
-            continue
-        values = line.split(None, 6)
-        if len(values) < 6:
-            continue
-        if len(values) == 6:
-            values.append("-")
-        yield {"_id": uuid.uuid4().hex, "uniprot": dict(zip(_HUMSAVAR_FIELDS, values))}
+        row = _parse_humsavar_line(line)
+        if row:
+            yield row
+
+
+def _parse_variation_line(line):
+    """
+    Parse one homo_sapiens_variation.txt data line (tab-delimited, 14
+    columns; see the file's own header for the full column list). Returns
+    None for blank/malformed lines.
+    """
+    line = line.rstrip("\n")
+    if not line:
+        return None
+    cols = line.split("\t")
+    if len(cols) < 10:
+        return None
+    return {
+        "source_db_id": cols[3],
+        "clinical_significance": cols[5],
+        "phenotype_disease": cols[6],
+        "phenotype_disease_source": cols[7],
+        "coordinate": cols[9],
+    }
 
 
 def parse_variation(lines):
-    """Yield one {"uniprot": {...}} document per homo_sapiens_variation.txt
-    data line, verbatim, skipping the multi-line preamble/header."""
+    """Parse homo_sapiens_variation.txt(.gz) content (an iterable of lines),
+    skipping the multi-line preamble/header. Yields one dict per data row."""
     started = False
     for line in lines:
         if line.startswith("___________"):
@@ -77,28 +133,191 @@ def parse_variation(lines):
             continue
         if not started:
             continue
-        line = line.rstrip("\n")
-        if not line:
+        row = _parse_variation_line(line)
+        if row:
+            yield row
+
+
+def build_variation_aggregate(rows):
+    """
+    Single pass over ALL homo_sapiens_variation.txt(.gz) rows (as produced by
+    parse_variation()), aggregating every row by its genomic coordinate --
+    every coordinate found here ends up as an output document.
+
+    Returns {coordinate: {"source_db_id": set(), "clinical_significance": set(),
+                           "phenotype_disease": set(), "phenotype_disease_source": set()}}
+    """
+    coordinate_info = {}
+    for row in rows:
+        coordinate = row["coordinate"]
+        info = coordinate_info.get(coordinate)
+        if info is None:
+            info = {
+                "source_db_id": set(),
+                "clinical_significance": set(),
+                "phenotype_disease": set(),
+                "phenotype_disease_source": set(),
+            }
+            coordinate_info[coordinate] = info
+        info["source_db_id"].add(row["source_db_id"])
+        for key in ("clinical_significance", "phenotype_disease", "phenotype_disease_source"):
+            value = row[key]
+            if value and value != "-":
+                info[key].add(value)
+    return coordinate_info
+
+
+def build_humsavar_index(humsavar_rows):
+    """
+    {dbsnp_id: [humsavar_row, ...]} -- a dbSNP id can be shared by more than
+    one humsavar record (real case: ABCA1's VAR_009147 and VAR_062487 both
+    cite rs137854496, an un-cleaned-up UniProt curation duplicate), so each
+    dbSNP id maps to a list rather than a single record. Rows with no dbSNP
+    id at all aren't included here -- they can never match a coordinate, so
+    build_docs() handles them separately, as standalone documents.
+    """
+    index = {}
+    for row in humsavar_rows:
+        if not row["dbsnp_id"]:
             continue
-        values = line.split("\t")
-        if len(values) < len(_VARIATION_FIELDS):
+        index.setdefault(row["dbsnp_id"], []).append(row)
+    return index
+
+
+def _humsavar_record(row):
+    record = {
+        "swiss_prot_ac": row["swiss_prot_ac"],
+        "ftid": row["ftid"],
+        "type_of_variant": row["type_of_variant"],
+    }
+    if row["disease_name"]:
+        record["disease_name"] = row["disease_name"]
+    return record
+
+
+def build_docs(coordinate_info, humsavar_rows):
+    """
+    Yield one document per genomic coordinate in coordinate_info (i.e. per
+    unique coordinate found in homo_sapiens_variation.txt.gz), 'humsavar'
+    attached whenever one of that coordinate's source_db_id values matches a
+    dbSNP id in humsavar_rows -- these are the documents with data from both
+    files.
+
+    Then yield one standalone document for every humsavar_rows record that
+    never got attached to a coordinate this way (no dbSNP id at all, or a
+    dbSNP id that never appears in homo_sapiens_variation.txt.gz) -- every
+    humsavar record must end up as a document somewhere. These get a random
+    _id (a uuid4 hex string), since there's no genomic coordinate to derive
+    a real one from.
+    """
+    humsavar_index = build_humsavar_index(humsavar_rows)
+    used_ftids = set()
+
+    for coordinate, info in coordinate_info.items():
+        _id = nc_coordinate_to_hgvs_id(coordinate)
+        if not _id:
             continue
-        yield {"_id": uuid.uuid4().hex, "uniprot": dict(zip(_VARIATION_FIELDS, values))}
+
+        doc = {"_id": _id, "uniprot": {}}
+        for key in ("source_db_id", "clinical_significance", "phenotype_disease", "phenotype_disease_source"):
+            values = info.get(key)
+            if values:
+                doc["uniprot"][key] = sorted(values)
+
+        matched = {}
+        for source_id in info["source_db_id"]:
+            for row in humsavar_index.get(source_id, []):
+                matched[row["ftid"]] = row
+        if matched:
+            used_ftids.update(matched)
+            records = [_humsavar_record(row) for row in matched.values()]
+            doc["uniprot"]["humsavar"] = records[0] if len(records) == 1 else records
+
+        yield unlist(doc)
+
+    for row in humsavar_rows:
+        if row["ftid"] in used_ftids:
+            continue
+        yield {"_id": uuid.uuid4().hex, "uniprot": {"humsavar": _humsavar_record(row)}}
+
+
+def merge_docs(docs):
+    """
+    Two distinct raw 'Chromosome Coordinate' strings can normalize to the
+    same _id (e.g. differing only by RefSeq patch version), so build_docs()
+    can still yield more than one document for the same _id even though it
+    iterates coordinate_info's already-unique keys. Storage does a plain
+    insert (not an upsert), so two documents with the same _id would crash
+    the whole batch with a MongoDB duplicate key error. (Standalone
+    humsavar-only documents use a random _id, so they never collide here.)
+
+    Groups by _id and merges each group into a single document: when more
+    than one distinct humsavar record ends up attached to the same _id,
+    'humsavar' becomes a list of records (as build_docs() already does for
+    multiple matches within one coordinate) and the enrichment fields are
+    unioned across all colliding rows.
+    """
+    grouped = {}
+    for doc in docs:
+        grouped.setdefault(doc["_id"], []).append(doc)
+
+    for _id, group in grouped.items():
+        if len(group) == 1:
+            yield group[0]
+            continue
+
+        merged = {"_id": _id, "uniprot": {}}
+
+        humsavar_by_ftid = {}
+        for d in group:
+            humsavar = d["uniprot"].get("humsavar")
+            if humsavar is None:
+                continue
+            records = humsavar if isinstance(humsavar, list) else [humsavar]
+            for record in records:
+                humsavar_by_ftid[record["ftid"]] = record
+        if humsavar_by_ftid:
+            records = list(humsavar_by_ftid.values())
+            merged["uniprot"]["humsavar"] = records[0] if len(records) == 1 else records
+
+        for key in ("source_db_id", "clinical_significance", "phenotype_disease", "phenotype_disease_source"):
+            values = set()
+            for d in group:
+                value = d["uniprot"].get(key)
+                if value is None:
+                    continue
+                values.update(value) if isinstance(value, list) else values.add(value)
+            if values:
+                merged["uniprot"][key] = sorted(values)
+        yield unlist(merged)
 
 
 def load_data(data_folder, logger=None):
+    logger = logger or logging.getLogger(__name__)
+
     humsavar_file = os.path.join(data_folder, HUMSAVAR_FILE)
     variation_files = glob.glob(os.path.join(data_folder, VARIATION_FILE_GLOB))
     assert len(variation_files) == 1, "Expecting exactly one file matching '%s', got: %s" % (
         VARIATION_FILE_GLOB, variation_files)
     variation_file = variation_files[0]
 
-    if logger:
-        logger.info("Loading '%s'" % HUMSAVAR_FILE)
     with open(humsavar_file, encoding="utf-8", errors="replace") as f:
-        yield from parse_humsavar(f)
+        humsavar_rows = list(parse_humsavar(f))
+    logger.info("Parsed %d humsavar.txt records" % len(humsavar_rows))
 
-    if logger:
-        logger.info("Loading '%s'" % VARIATION_FILE_GLOB)
     with gzip.open(variation_file, "rt", encoding="utf-8", errors="replace") as f:
-        yield from parse_variation(f)
+        coordinate_info = build_variation_aggregate(parse_variation(f))
+    logger.info("Aggregated %d unique genomic coordinates from '%s'" %
+                (len(coordinate_info), VARIATION_FILE_GLOB))
+
+    raw_docs = list(build_docs(coordinate_info, humsavar_rows))
+    with_humsavar = sum(1 for d in raw_docs if "humsavar" in d["uniprot"])
+    standalone_humsavar = sum(1 for d in raw_docs if set(d["uniprot"].keys()) == {"humsavar"})
+    logger.info("Built %d documents (%d with a humsavar match, %d humsavar-only with no genomic match)" %
+                (len(raw_docs), with_humsavar, standalone_humsavar))
+
+    docs = list(merge_docs(raw_docs))
+    if len(docs) != len(raw_docs):
+        logger.info("Merged %d colliding documents sharing an _id down to %d" %
+                    (len(raw_docs), len(docs)))
+    return docs

--- a/src/hub/dataload/sources/uniprot/uniprot_parser.py
+++ b/src/hub/dataload/sources/uniprot/uniprot_parser.py
@@ -1,89 +1,45 @@
 """
-Parses the two UniProtKB variant files (see uniprot_dump.py for how they're
-fetched) into 'uniprot' myvariant.info documents:
+Loads humsavar.txt and homo_sapiens_variation.txt.gz as-is into 'uniprot'
+documents: one document per line in either file, verbatim. There is no
+deduplication, no merging of rows, and no correlation between the two files
+-- each line becomes its own independent document with no computed _id
+(MongoDB assigns one automatically on insert).
 
-  - homo_sapiens_variation.txt.gz: bulk protein-altering variant index (59M+
-    rows, mostly dbSNP/ClinVar-sourced). This is the base: every unique
-    genomic coordinate found here becomes one output document, populated
-    with whatever 'source_db_id' / 'clinical_significance' /
-    'phenotype_disease' / 'phenotype_disease_source' values UniProt reports
-    at that position (every source sharing the coordinate -- rs, RCV, or
-    anything else -- not just one).
-  - humsavar.txt: manually curated missense variants, ~85K records. It has
-    no genomic coordinate of its own (only a dbSNP id), so its fields are
-    attached to a document only when one of that document's source_db_id
-    values matches a dbSNP id in humsavar.txt. Most documents (the vast
-    majority of the ~15M unique coordinates in the variation file have no
-    curated humsavar record) won't have a 'humsavar' field at all.
-
-Rows whose 'Chromosome Coordinate' isn't a recognized GRCh38 chromosome
-accession are skipped: without a genomic coordinate there is no way to build
-the 'chrN:g.posREF>ALT' _id myvariant.info requires.
+Column names already used elsewhere in this mapping are reused
+(source_db_id, clinical_significance, phenotype_disease,
+phenotype_disease_source, swiss_prot_ac, ftid, type_of_variant,
+disease_name); every other column is stored under a name derived from its
+own header (see _HUMSAVAR_FIELDS / _VARIATION_FIELDS below).
 """
 import glob
 import gzip
-import logging
 import os
-
-from biothings.utils.dataload import unlist
 
 HUMSAVAR_FILE = "humsavar.txt"
 VARIATION_FILE_GLOB = "homo_sapiens_variation.txt.gz"
 
-# GRCh38 RefSeq chromosome accession prefix (before the version suffix) ->
-# myvariant.info chromosome name.
-_NC_TO_CHROM = {("NC_%06d" % i): str(i) for i in range(1, 23)}
-_NC_TO_CHROM["NC_000023"] = "X"
-_NC_TO_CHROM["NC_000024"] = "Y"
-_NC_TO_CHROM["NC_012920"] = "MT"
+# humsavar.txt columns, in file order: Main gene name | Swiss-Prot AC | FTId |
+# AA change | Variant category | dbSNP | Disease name
+_HUMSAVAR_FIELDS = [
+    "gene_name", "swiss_prot_ac", "ftid", "aa_change", "type_of_variant", "dbsnp", "disease_name",
+]
 
-
-def nc_coordinate_to_hgvs_id(coordinate):
-    """
-    Convert a UniProt 'Chromosome Coordinate' value, e.g.
-    'NC_000017.11:g.30178149A>G', into a myvariant.info _id, e.g.
-    'chr17:g.30178149A>G'. Returns None if the accession isn't a recognized
-    GRCh38 chromosome accession.
-    """
-    accession, sep, rest = coordinate.partition(":")
-    if not sep:
-        return None
-    prefix = accession.split(".")[0]
-    chrom = _NC_TO_CHROM.get(prefix)
-    if not chrom:
-        return None
-    return "chr%s:%s" % (chrom, rest)
-
-
-def _parse_humsavar_line(line):
-    """
-    Parse one humsavar.txt data line (fixed-width/whitespace separated, NOT
-    tab-delimited):
-        A1BG        P04217     VAR_018369  p.His52Arg     LB/B     rs893184       -
-    Columns: gene name, Swiss-Prot AC, FTId, AA change, variant category,
-    dbSNP id, disease name (free text, may itself contain spaces).
-    Returns None for blank/malformed lines.
-    """
-    line = line.rstrip("\n")
-    if not line.strip():
-        return None
-    parts = line.split(None, 6)
-    if len(parts) < 6:
-        return None
-    _gene_name, swiss_prot_ac, ftid, _aa_change, type_of_variant, dbsnp_id = parts[:6]
-    disease_name = parts[6] if len(parts) == 7 else "-"
-    return {
-        "swiss_prot_ac": swiss_prot_ac,
-        "ftid": ftid,
-        "type_of_variant": type_of_variant,
-        "dbsnp_id": None if dbsnp_id == "-" else dbsnp_id,
-        "disease_name": None if disease_name == "-" else disease_name,
-    }
+# homo_sapiens_variation.txt.gz columns, in file order: Gene Name | AC |
+# Variant AA Change | Source DB ID | Consequence Type | Clinical
+# Significance | Phenotype/Disease | Phenotype/Disease Source | Cytogenetic
+# Band | Chromosome Coordinate | Ensembl gene ID | Ensembl transcript ID |
+# Ensembl translation ID | Evidence
+_VARIATION_FIELDS = [
+    "gene_name", "swiss_prot_ac", "aa_change", "source_db_id", "consequence_type",
+    "clinical_significance", "phenotype_disease", "phenotype_disease_source",
+    "cytogenetic_band", "chromosome_coordinate", "ensembl_gene_id",
+    "ensembl_transcript_id", "ensembl_translation_id", "evidence",
+]
 
 
 def parse_humsavar(lines):
-    """Parse humsavar.txt content (an iterable of lines), skipping the
-    multi-line preamble/header. Yields one dict per data row."""
+    """Yield one {"uniprot": {...}} document per humsavar.txt data line,
+    verbatim, skipping the multi-line preamble/header."""
     started = False
     for line in lines:
         if line.startswith("_________"):
@@ -91,35 +47,20 @@ def parse_humsavar(lines):
             continue
         if not started:
             continue
-        row = _parse_humsavar_line(line)
-        if row:
-            yield row
-
-
-def _parse_variation_line(line):
-    """
-    Parse one homo_sapiens_variation.txt data line (tab-delimited, 14
-    columns; see the file's own header for the full column list). Returns
-    None for blank/malformed lines.
-    """
-    line = line.rstrip("\n")
-    if not line:
-        return None
-    cols = line.split("\t")
-    if len(cols) < 10:
-        return None
-    return {
-        "source_db_id": cols[3],
-        "clinical_significance": cols[5],
-        "phenotype_disease": cols[6],
-        "phenotype_disease_source": cols[7],
-        "coordinate": cols[9],
-    }
+        line = line.rstrip("\n")
+        if not line.strip():
+            continue
+        values = line.split(None, 6)
+        if len(values) < 6:
+            continue
+        if len(values) == 6:
+            values.append("-")
+        yield {"uniprot": dict(zip(_HUMSAVAR_FIELDS, values))}
 
 
 def parse_variation(lines):
-    """Parse homo_sapiens_variation.txt(.gz) content (an iterable of lines),
-    skipping the multi-line preamble/header. Yields one dict per data row."""
+    """Yield one {"uniprot": {...}} document per homo_sapiens_variation.txt
+    data line, verbatim, skipping the multi-line preamble/header."""
     started = False
     for line in lines:
         if line.startswith("___________"):
@@ -127,171 +68,28 @@ def parse_variation(lines):
             continue
         if not started:
             continue
-        row = _parse_variation_line(line)
-        if row:
-            yield row
-
-
-def build_variation_aggregate(rows):
-    """
-    Single pass over ALL homo_sapiens_variation.txt(.gz) rows (as produced by
-    parse_variation()), aggregating every row by its genomic coordinate --
-    this file is the base of this source, so every coordinate found here
-    ends up as an output document, not just a pre-selected subset.
-
-    Returns {coordinate: {"source_db_id": set(), "clinical_significance": set(),
-                           "phenotype_disease": set(), "phenotype_disease_source": set()}}
-    """
-    coordinate_info = {}
-    for row in rows:
-        coordinate = row["coordinate"]
-        info = coordinate_info.get(coordinate)
-        if info is None:
-            info = {
-                "source_db_id": set(),
-                "clinical_significance": set(),
-                "phenotype_disease": set(),
-                "phenotype_disease_source": set(),
-            }
-            coordinate_info[coordinate] = info
-        info["source_db_id"].add(row["source_db_id"])
-        for key in ("clinical_significance", "phenotype_disease", "phenotype_disease_source"):
-            value = row[key]
-            if value and value != "-":
-                info[key].add(value)
-    return coordinate_info
-
-
-def build_humsavar_index(humsavar_rows):
-    """
-    {dbsnp_id: [humsavar_record, ...]} -- a dbSNP id can be shared by more
-    than one humsavar record (real case: ABCA1's VAR_009147 and VAR_062487
-    both cite rs137854496, an un-cleaned-up UniProt curation duplicate), so
-    each dbSNP id maps to a list rather than a single record.
-    """
-    index = {}
-    for row in humsavar_rows:
-        if not row["dbsnp_id"]:
+        line = line.rstrip("\n")
+        if not line:
             continue
-        record = {
-            "swiss_prot_ac": row["swiss_prot_ac"],
-            "ftid": row["ftid"],
-            "type_of_variant": row["type_of_variant"],
-        }
-        if row["disease_name"]:
-            record["disease_name"] = row["disease_name"]
-        index.setdefault(row["dbsnp_id"], []).append(record)
-    return index
-
-
-def build_docs(coordinate_info, humsavar_index):
-    """
-    Yield one 'uniprot' document per genomic coordinate in coordinate_info
-    (i.e. per unique coordinate found in homo_sapiens_variation.txt.gz).
-    'humsavar' is attached only when one of the coordinate's source_db_id
-    values matches a dbSNP id in humsavar_index -- most documents won't have
-    one, since humsavar.txt (~85K records) is a small subset of all the
-    coordinates in the base file (~15M).
-    """
-    for coordinate, info in coordinate_info.items():
-        _id = nc_coordinate_to_hgvs_id(coordinate)
-        if not _id:
+        values = line.split("\t")
+        if len(values) < len(_VARIATION_FIELDS):
             continue
-
-        doc = {"_id": _id, "uniprot": {}}
-        for key in ("source_db_id", "clinical_significance", "phenotype_disease", "phenotype_disease_source"):
-            values = info.get(key)
-            if values:
-                doc["uniprot"][key] = sorted(values)
-
-        humsavar_by_ftid = {}
-        for source_id in info["source_db_id"]:
-            for record in humsavar_index.get(source_id, []):
-                humsavar_by_ftid[record["ftid"]] = record
-        if humsavar_by_ftid:
-            records = list(humsavar_by_ftid.values())
-            doc["uniprot"]["humsavar"] = records[0] if len(records) == 1 else records
-
-        yield unlist(doc)
-
-
-def merge_docs(docs):
-    """
-    Two distinct raw 'Chromosome Coordinate' strings can normalize to the
-    same _id (e.g. differing only by RefSeq patch version), so build_docs()
-    can still yield more than one document for the same _id even though it
-    iterates coordinate_info's already-unique keys. Storage does a plain
-    insert (not an upsert), so two documents with the same _id would crash
-    the whole batch with a MongoDB duplicate key error.
-
-    Groups by _id and merges each group into a single document: when more
-    than one distinct humsavar record ends up attached to the same _id,
-    'humsavar' becomes a list of records (as build_docs() already does for
-    multiple matches within one coordinate) and the enrichment fields are
-    unioned across all colliding rows.
-    """
-    grouped = {}
-    for doc in docs:
-        grouped.setdefault(doc["_id"], []).append(doc)
-
-    for _id, group in grouped.items():
-        if len(group) == 1:
-            yield group[0]
-            continue
-
-        merged = {"_id": _id, "uniprot": {}}
-
-        humsavar_by_ftid = {}
-        for d in group:
-            humsavar = d["uniprot"].get("humsavar")
-            if humsavar is None:
-                continue
-            records = humsavar if isinstance(humsavar, list) else [humsavar]
-            for record in records:
-                humsavar_by_ftid[record["ftid"]] = record
-        if humsavar_by_ftid:
-            records = list(humsavar_by_ftid.values())
-            merged["uniprot"]["humsavar"] = records[0] if len(records) == 1 else records
-
-        for key in ("source_db_id", "clinical_significance", "phenotype_disease", "phenotype_disease_source"):
-            values = set()
-            for d in group:
-                value = d["uniprot"].get(key)
-                if value is None:
-                    continue
-                values.update(value) if isinstance(value, list) else values.add(value)
-            if values:
-                merged["uniprot"][key] = sorted(values)
-        yield unlist(merged)
+        yield {"uniprot": dict(zip(_VARIATION_FIELDS, values))}
 
 
 def load_data(data_folder, logger=None):
-    logger = logger or logging.getLogger(__name__)
-
     humsavar_file = os.path.join(data_folder, HUMSAVAR_FILE)
     variation_files = glob.glob(os.path.join(data_folder, VARIATION_FILE_GLOB))
     assert len(variation_files) == 1, "Expecting exactly one file matching '%s', got: %s" % (
         VARIATION_FILE_GLOB, variation_files)
     variation_file = variation_files[0]
 
+    if logger:
+        logger.info("Loading '%s'" % HUMSAVAR_FILE)
     with open(humsavar_file, encoding="utf-8", errors="replace") as f:
-        humsavar_rows = list(parse_humsavar(f))
-    humsavar_index = build_humsavar_index(humsavar_rows)
-    logger.info("Parsed %d humsavar.txt records (%d distinct dbSNP ids)" %
-                (len(humsavar_rows), len(humsavar_index)))
+        yield from parse_humsavar(f)
 
+    if logger:
+        logger.info("Loading '%s'" % VARIATION_FILE_GLOB)
     with gzip.open(variation_file, "rt", encoding="utf-8", errors="replace") as f:
-        coordinate_info = build_variation_aggregate(parse_variation(f))
-    logger.info("Aggregated %d unique genomic coordinates from '%s'" %
-                (len(coordinate_info), VARIATION_FILE_GLOB))
-
-    raw_docs = list(build_docs(coordinate_info, humsavar_index))
-    with_humsavar = sum(1 for d in raw_docs if "humsavar" in d["uniprot"])
-    logger.info("Built %d uniprot documents (%d with a humsavar match)" %
-                (len(raw_docs), with_humsavar))
-
-    docs = list(merge_docs(raw_docs))
-    if len(docs) != len(raw_docs):
-        logger.info("Merged %d colliding documents sharing an _id down to %d" %
-                    (len(raw_docs), len(docs)))
-    return docs
+        yield from parse_variation(f)

--- a/src/hub/dataload/sources/uniprot/uniprot_parser.py
+++ b/src/hub/dataload/sources/uniprot/uniprot_parser.py
@@ -1,20 +1,23 @@
 """
 Parses the two UniProtKB variant files (see uniprot_dump.py for how they're
-fetched) into 'uniprot' myvariant.info documents, loading ALL data from
+fetched) into 'uniprot' myvariant.info documents, loading ALL columns from
 BOTH files and connecting records that relate to each other:
 
   - homo_sapiens_variation.txt.gz: bulk protein-altering variant index (59M+
     rows, mostly dbSNP/ClinVar-sourced). Every unique genomic coordinate
-    found here becomes one output document, populated with whatever
-    'source_db_id' / 'clinical_significance' / 'phenotype_disease' /
-    'phenotype_disease_source' values UniProt reports at that position
-    (every source sharing the coordinate -- rs, RCV, or anything else, not
-    just one).
-  - humsavar.txt: manually curated missense variants, ~85K records. It has
-    no genomic coordinate of its own (only a dbSNP id). When a record's
-    dbSNP id matches one of a coordinate's source_db_id values, its fields
-    are attached to that coordinate's document -- so some documents end up
-    with data from both files. When a record's dbSNP id doesn't match
+    found here becomes one output document, populated with every column
+    UniProt reports at that position -- gene name, AC, AA change, source_db_id,
+    consequence_type, clinical_significance, phenotype_disease,
+    phenotype_disease_source, cytogenetic_band, and the Ensembl gene/
+    transcript/translation ids and evidence sources -- aggregated across
+    every row sharing the coordinate (e.g. multiple Ensembl transcripts, or
+    multiple sources like rs/RCV at one position), not just one row.
+  - humsavar.txt: manually curated missense variants, ~85K records, with
+    gene name, Swiss-Prot AC, FTId, AA change, variant category, and disease
+    name. It has no genomic coordinate of its own (only a dbSNP id). When a
+    record's dbSNP id matches one of a coordinate's source_db_id values, its
+    fields are attached to that coordinate's document -- so some documents
+    end up with data from both files. When a record's dbSNP id doesn't match
     anything in the variation file (or it has no dbSNP id at all -- about
     17% of humsavar.txt), it still becomes its own standalone document
     (humsavar-only, no genomic coordinate to derive a real _id from, so it
@@ -42,6 +45,18 @@ _NC_TO_CHROM = {("NC_%06d" % i): str(i) for i in range(1, 23)}
 _NC_TO_CHROM["NC_000023"] = "X"
 _NC_TO_CHROM["NC_000024"] = "Y"
 _NC_TO_CHROM["NC_012920"] = "MT"
+
+# homo_sapiens_variation.txt.gz columns that get aggregated (unioned as a set
+# per coordinate, since multiple rows -- e.g. different Ensembl transcripts --
+# can share the same coordinate). source_db_id is aggregated the same way but
+# handled separately below since, unlike these, it's never a '-' placeholder.
+_VARIATION_SET_FIELDS = (
+    "gene_name", "swiss_prot_ac", "aa_change", "consequence_type",
+    "clinical_significance", "phenotype_disease", "phenotype_disease_source",
+    "cytogenetic_band", "ensembl_gene_id", "ensembl_transcript_id",
+    "ensembl_translation_id", "evidence",
+)
+_ALL_VARIATION_FIELDS = ("source_db_id",) + _VARIATION_SET_FIELDS
 
 
 def nc_coordinate_to_hgvs_id(coordinate):
@@ -76,11 +91,13 @@ def _parse_humsavar_line(line):
     parts = line.split(None, 6)
     if len(parts) < 6:
         return None
-    _gene_name, swiss_prot_ac, ftid, _aa_change, type_of_variant, dbsnp_id = parts[:6]
+    gene_name, swiss_prot_ac, ftid, aa_change, type_of_variant, dbsnp_id = parts[:6]
     disease_name = parts[6] if len(parts) == 7 else "-"
     return {
+        "gene_name": gene_name,
         "swiss_prot_ac": swiss_prot_ac,
         "ftid": ftid,
+        "aa_change": aa_change,
         "type_of_variant": type_of_variant,
         "dbsnp_id": None if dbsnp_id == "-" else dbsnp_id,
         "disease_name": None if disease_name == "-" else disease_name,
@@ -105,21 +122,33 @@ def parse_humsavar(lines):
 def _parse_variation_line(line):
     """
     Parse one homo_sapiens_variation.txt data line (tab-delimited, 14
-    columns; see the file's own header for the full column list). Returns
-    None for blank/malformed lines.
+    columns): Gene Name, AC, Variant AA Change, Source DB ID, Consequence
+    Type, Clinical Significance, Phenotype/Disease, Phenotype/Disease
+    Source, Cytogenetic Band, Chromosome Coordinate, Ensembl gene ID,
+    Ensembl transcript ID, Ensembl translation ID, Evidence.
+    Returns None for blank/malformed lines.
     """
     line = line.rstrip("\n")
     if not line:
         return None
     cols = line.split("\t")
-    if len(cols) < 10:
+    if len(cols) < 14:
         return None
     return {
+        "gene_name": cols[0],
+        "swiss_prot_ac": cols[1],
+        "aa_change": cols[2],
         "source_db_id": cols[3],
+        "consequence_type": cols[4],
         "clinical_significance": cols[5],
         "phenotype_disease": cols[6],
         "phenotype_disease_source": cols[7],
+        "cytogenetic_band": cols[8],
         "coordinate": cols[9],
+        "ensembl_gene_id": cols[10],
+        "ensembl_transcript_id": cols[11],
+        "ensembl_translation_id": cols[12],
+        "evidence": cols[13],
     }
 
 
@@ -142,25 +171,23 @@ def build_variation_aggregate(rows):
     """
     Single pass over ALL homo_sapiens_variation.txt(.gz) rows (as produced by
     parse_variation()), aggregating every row by its genomic coordinate --
-    every coordinate found here ends up as an output document.
+    every coordinate found here ends up as an output document. Every column
+    is aggregated as a set (source_db_id unconditionally; the rest skip '-'
+    placeholder values), since multiple rows -- e.g. different Ensembl
+    transcripts -- can share the same coordinate with different values.
 
-    Returns {coordinate: {"source_db_id": set(), "clinical_significance": set(),
-                           "phenotype_disease": set(), "phenotype_disease_source": set()}}
+    Returns {coordinate: {field: set(), ...}} with one set per field in
+    _ALL_VARIATION_FIELDS.
     """
     coordinate_info = {}
     for row in rows:
         coordinate = row["coordinate"]
         info = coordinate_info.get(coordinate)
         if info is None:
-            info = {
-                "source_db_id": set(),
-                "clinical_significance": set(),
-                "phenotype_disease": set(),
-                "phenotype_disease_source": set(),
-            }
+            info = {key: set() for key in _ALL_VARIATION_FIELDS}
             coordinate_info[coordinate] = info
         info["source_db_id"].add(row["source_db_id"])
-        for key in ("clinical_significance", "phenotype_disease", "phenotype_disease_source"):
+        for key in _VARIATION_SET_FIELDS:
             value = row[key]
             if value and value != "-":
                 info[key].add(value)
@@ -186,8 +213,10 @@ def build_humsavar_index(humsavar_rows):
 
 def _humsavar_record(row):
     record = {
+        "gene_name": row["gene_name"],
         "swiss_prot_ac": row["swiss_prot_ac"],
         "ftid": row["ftid"],
+        "aa_change": row["aa_change"],
         "type_of_variant": row["type_of_variant"],
     }
     if row["disease_name"]:
@@ -219,7 +248,7 @@ def build_docs(coordinate_info, humsavar_rows):
             continue
 
         doc = {"_id": _id, "uniprot": {}}
-        for key in ("source_db_id", "clinical_significance", "phenotype_disease", "phenotype_disease_source"):
+        for key in _ALL_VARIATION_FIELDS:
             values = info.get(key)
             if values:
                 doc["uniprot"][key] = sorted(values)
@@ -280,7 +309,7 @@ def merge_docs(docs):
             records = list(humsavar_by_ftid.values())
             merged["uniprot"]["humsavar"] = records[0] if len(records) == 1 else records
 
-        for key in ("source_db_id", "clinical_significance", "phenotype_disease", "phenotype_disease_source"):
+        for key in _ALL_VARIATION_FIELDS:
             values = set()
             for d in group:
                 value = d["uniprot"].get(key)

--- a/src/hub/dataload/sources/uniprot/uniprot_parser.py
+++ b/src/hub/dataload/sources/uniprot/uniprot_parser.py
@@ -1,20 +1,14 @@
 """
-Parses the two UniProtKB variant files (see uniprot_dump.py for how they're
-fetched) into 'uniprot' myvariant.info documents:
+Parses homo_sapiens_variation.txt.gz (see uniprot_dump.py for how it's
+fetched) into 'uniprot' myvariant.info documents.
 
-  - homo_sapiens_variation.txt.gz: bulk protein-altering variant index (59M+
-    rows, mostly dbSNP/ClinVar-sourced). This is the base: every unique
-    genomic coordinate found here becomes one output document, populated
-    with whatever 'source_db_id' / 'clinical_significance' /
-    'phenotype_disease' / 'phenotype_disease_source' values UniProt reports
-    at that position (every source sharing the coordinate -- rs, RCV, or
-    anything else -- not just one).
-  - humsavar.txt: manually curated missense variants, ~85K records. It has
-    no genomic coordinate of its own (only a dbSNP id), so its fields are
-    attached to a document only when one of that document's source_db_id
-    values matches a dbSNP id in humsavar.txt. Most documents (the vast
-    majority of the ~15M unique coordinates in the variation file have no
-    curated humsavar record) won't have a 'humsavar' field at all.
+homo_sapiens_variation.txt.gz is a bulk protein-altering variant index (59M+
+rows, mostly dbSNP/ClinVar-sourced, one row per variant per Ensembl
+transcript/phenotype). Every unique genomic coordinate found in it becomes
+one output document, populated with whatever 'source_db_id' /
+'clinical_significance' / 'phenotype_disease' / 'phenotype_disease_source'
+values UniProt reports at that position -- every source sharing the
+coordinate (rs, RCV, or anything else), not just one.
 
 Rows whose 'Chromosome Coordinate' isn't a recognized GRCh38 chromosome
 accession are skipped: without a genomic coordinate there is no way to build
@@ -27,7 +21,6 @@ import os
 
 from biothings.utils.dataload import unlist
 
-HUMSAVAR_FILE = "humsavar.txt"
 VARIATION_FILE_GLOB = "homo_sapiens_variation.txt.gz"
 
 # GRCh38 RefSeq chromosome accession prefix (before the version suffix) ->
@@ -53,47 +46,6 @@ def nc_coordinate_to_hgvs_id(coordinate):
     if not chrom:
         return None
     return "chr%s:%s" % (chrom, rest)
-
-
-def _parse_humsavar_line(line):
-    """
-    Parse one humsavar.txt data line (fixed-width/whitespace separated, NOT
-    tab-delimited):
-        A1BG        P04217     VAR_018369  p.His52Arg     LB/B     rs893184       -
-    Columns: gene name, Swiss-Prot AC, FTId, AA change, variant category,
-    dbSNP id, disease name (free text, may itself contain spaces).
-    Returns None for blank/malformed lines.
-    """
-    line = line.rstrip("\n")
-    if not line.strip():
-        return None
-    parts = line.split(None, 6)
-    if len(parts) < 6:
-        return None
-    _gene_name, swiss_prot_ac, ftid, _aa_change, type_of_variant, dbsnp_id = parts[:6]
-    disease_name = parts[6] if len(parts) == 7 else "-"
-    return {
-        "swiss_prot_ac": swiss_prot_ac,
-        "ftid": ftid,
-        "type_of_variant": type_of_variant,
-        "dbsnp_id": None if dbsnp_id == "-" else dbsnp_id,
-        "disease_name": None if disease_name == "-" else disease_name,
-    }
-
-
-def parse_humsavar(lines):
-    """Parse humsavar.txt content (an iterable of lines), skipping the
-    multi-line preamble/header. Yields one dict per data row."""
-    started = False
-    for line in lines:
-        if line.startswith("_________"):
-            started = True
-            continue
-        if not started:
-            continue
-        row = _parse_humsavar_line(line)
-        if row:
-            yield row
 
 
 def _parse_variation_line(line):
@@ -136,8 +88,7 @@ def build_variation_aggregate(rows):
     """
     Single pass over ALL homo_sapiens_variation.txt(.gz) rows (as produced by
     parse_variation()), aggregating every row by its genomic coordinate --
-    this file is the base of this source, so every coordinate found here
-    ends up as an output document, not just a pre-selected subset.
+    every coordinate found here ends up as an output document.
 
     Returns {coordinate: {"source_db_id": set(), "clinical_significance": set(),
                            "phenotype_disease": set(), "phenotype_disease_source": set()}}
@@ -162,36 +113,10 @@ def build_variation_aggregate(rows):
     return coordinate_info
 
 
-def build_humsavar_index(humsavar_rows):
-    """
-    {dbsnp_id: [humsavar_record, ...]} -- a dbSNP id can be shared by more
-    than one humsavar record (real case: ABCA1's VAR_009147 and VAR_062487
-    both cite rs137854496, an un-cleaned-up UniProt curation duplicate), so
-    each dbSNP id maps to a list rather than a single record.
-    """
-    index = {}
-    for row in humsavar_rows:
-        if not row["dbsnp_id"]:
-            continue
-        record = {
-            "swiss_prot_ac": row["swiss_prot_ac"],
-            "ftid": row["ftid"],
-            "type_of_variant": row["type_of_variant"],
-        }
-        if row["disease_name"]:
-            record["disease_name"] = row["disease_name"]
-        index.setdefault(row["dbsnp_id"], []).append(record)
-    return index
-
-
-def build_docs(coordinate_info, humsavar_index):
+def build_docs(coordinate_info):
     """
     Yield one 'uniprot' document per genomic coordinate in coordinate_info
     (i.e. per unique coordinate found in homo_sapiens_variation.txt.gz).
-    'humsavar' is attached only when one of the coordinate's source_db_id
-    values matches a dbSNP id in humsavar_index -- most documents won't have
-    one, since humsavar.txt (~85K records) is a small subset of all the
-    coordinates in the base file (~15M).
     """
     for coordinate, info in coordinate_info.items():
         _id = nc_coordinate_to_hgvs_id(coordinate)
@@ -203,14 +128,6 @@ def build_docs(coordinate_info, humsavar_index):
             values = info.get(key)
             if values:
                 doc["uniprot"][key] = sorted(values)
-
-        humsavar_by_ftid = {}
-        for source_id in info["source_db_id"]:
-            for record in humsavar_index.get(source_id, []):
-                humsavar_by_ftid[record["ftid"]] = record
-        if humsavar_by_ftid:
-            records = list(humsavar_by_ftid.values())
-            doc["uniprot"]["humsavar"] = records[0] if len(records) == 1 else records
 
         yield unlist(doc)
 
@@ -224,11 +141,8 @@ def merge_docs(docs):
     insert (not an upsert), so two documents with the same _id would crash
     the whole batch with a MongoDB duplicate key error.
 
-    Groups by _id and merges each group into a single document: when more
-    than one distinct humsavar record ends up attached to the same _id,
-    'humsavar' becomes a list of records (as build_docs() already does for
-    multiple matches within one coordinate) and the enrichment fields are
-    unioned across all colliding rows.
+    Groups by _id and merges each group into a single document, unioning the
+    enrichment fields across all colliding rows.
     """
     grouped = {}
     for doc in docs:
@@ -240,19 +154,6 @@ def merge_docs(docs):
             continue
 
         merged = {"_id": _id, "uniprot": {}}
-
-        humsavar_by_ftid = {}
-        for d in group:
-            humsavar = d["uniprot"].get("humsavar")
-            if humsavar is None:
-                continue
-            records = humsavar if isinstance(humsavar, list) else [humsavar]
-            for record in records:
-                humsavar_by_ftid[record["ftid"]] = record
-        if humsavar_by_ftid:
-            records = list(humsavar_by_ftid.values())
-            merged["uniprot"]["humsavar"] = records[0] if len(records) == 1 else records
-
         for key in ("source_db_id", "clinical_significance", "phenotype_disease", "phenotype_disease_source"):
             values = set()
             for d in group:
@@ -268,27 +169,18 @@ def merge_docs(docs):
 def load_data(data_folder, logger=None):
     logger = logger or logging.getLogger(__name__)
 
-    humsavar_file = os.path.join(data_folder, HUMSAVAR_FILE)
     variation_files = glob.glob(os.path.join(data_folder, VARIATION_FILE_GLOB))
     assert len(variation_files) == 1, "Expecting exactly one file matching '%s', got: %s" % (
         VARIATION_FILE_GLOB, variation_files)
     variation_file = variation_files[0]
-
-    with open(humsavar_file, encoding="utf-8", errors="replace") as f:
-        humsavar_rows = list(parse_humsavar(f))
-    humsavar_index = build_humsavar_index(humsavar_rows)
-    logger.info("Parsed %d humsavar.txt records (%d distinct dbSNP ids)" %
-                (len(humsavar_rows), len(humsavar_index)))
 
     with gzip.open(variation_file, "rt", encoding="utf-8", errors="replace") as f:
         coordinate_info = build_variation_aggregate(parse_variation(f))
     logger.info("Aggregated %d unique genomic coordinates from '%s'" %
                 (len(coordinate_info), VARIATION_FILE_GLOB))
 
-    raw_docs = list(build_docs(coordinate_info, humsavar_index))
-    with_humsavar = sum(1 for d in raw_docs if "humsavar" in d["uniprot"])
-    logger.info("Built %d uniprot documents (%d with a humsavar match)" %
-                (len(raw_docs), with_humsavar))
+    raw_docs = list(build_docs(coordinate_info))
+    logger.info("Built %d uniprot documents" % len(raw_docs))
 
     docs = list(merge_docs(raw_docs))
     if len(docs) != len(raw_docs):

--- a/src/hub/dataload/sources/uniprot/uniprot_parser.py
+++ b/src/hub/dataload/sources/uniprot/uniprot_parser.py
@@ -1,0 +1,245 @@
+"""
+Parses the two UniProtKB variant files (see uniprot_dump.py for how they're
+fetched) into 'uniprot' myvariant.info documents:
+
+  - humsavar.txt: manually curated missense variants. This drives which
+    variants end up in this source -- every output document corresponds to
+    exactly one humsavar.txt record.
+  - homo_sapiens_variation.txt.gz: bulk protein-altering variant index (59M+
+    rows, mostly dbSNP/ClinVar-sourced). humsavar.txt has no genomic
+    coordinate of its own (only a dbSNP id), so this file is used purely to
+    look up that coordinate and to enrich the record with whatever
+    'source_db_id' / 'clinical_significance' / 'phenotype_disease' /
+    'phenotype_disease_source' values UniProt reports at that genomic
+    position -- not just the one dbSNP id humsavar happens to reference, but
+    every source (rs, RCV, or anything else) sharing that same coordinate.
+
+humsavar.txt records with no dbSNP id, or whose dbSNP id can't be found in
+homo_sapiens_variation.txt.gz, are skipped: without a genomic coordinate there
+is no way to build the 'chrN:g.posREF>ALT' _id myvariant.info requires.
+"""
+import glob
+import gzip
+import logging
+import os
+
+from biothings.utils.dataload import unlist
+
+HUMSAVAR_FILE = "humsavar.txt"
+VARIATION_FILE_GLOB = "homo_sapiens_variation.txt.gz"
+
+# GRCh38 RefSeq chromosome accession prefix (before the version suffix) ->
+# myvariant.info chromosome name.
+_NC_TO_CHROM = {("NC_%06d" % i): str(i) for i in range(1, 23)}
+_NC_TO_CHROM["NC_000023"] = "X"
+_NC_TO_CHROM["NC_000024"] = "Y"
+_NC_TO_CHROM["NC_012920"] = "MT"
+
+
+def nc_coordinate_to_hgvs_id(coordinate):
+    """
+    Convert a UniProt 'Chromosome Coordinate' value, e.g.
+    'NC_000017.11:g.30178149A>G', into a myvariant.info _id, e.g.
+    'chr17:g.30178149A>G'. Returns None if the accession isn't a recognized
+    GRCh38 chromosome accession.
+    """
+    accession, sep, rest = coordinate.partition(":")
+    if not sep:
+        return None
+    prefix = accession.split(".")[0]
+    chrom = _NC_TO_CHROM.get(prefix)
+    if not chrom:
+        return None
+    return "chr%s:%s" % (chrom, rest)
+
+
+def _parse_humsavar_line(line):
+    """
+    Parse one humsavar.txt data line (fixed-width/whitespace separated, NOT
+    tab-delimited):
+        A1BG        P04217     VAR_018369  p.His52Arg     LB/B     rs893184       -
+    Columns: gene name, Swiss-Prot AC, FTId, AA change, variant category,
+    dbSNP id, disease name (free text, may itself contain spaces).
+    Returns None for blank/malformed lines.
+    """
+    line = line.rstrip("\n")
+    if not line.strip():
+        return None
+    parts = line.split(None, 6)
+    if len(parts) < 6:
+        return None
+    _gene_name, swiss_prot_ac, ftid, _aa_change, type_of_variant, dbsnp_id = parts[:6]
+    disease_name = parts[6] if len(parts) == 7 else "-"
+    return {
+        "swiss_prot_ac": swiss_prot_ac,
+        "ftid": ftid,
+        "type_of_variant": type_of_variant,
+        "dbsnp_id": None if dbsnp_id == "-" else dbsnp_id,
+        "disease_name": None if disease_name == "-" else disease_name,
+    }
+
+
+def parse_humsavar(lines):
+    """Parse humsavar.txt content (an iterable of lines), skipping the
+    multi-line preamble/header. Yields one dict per data row."""
+    started = False
+    for line in lines:
+        if line.startswith("_________"):
+            started = True
+            continue
+        if not started:
+            continue
+        row = _parse_humsavar_line(line)
+        if row:
+            yield row
+
+
+def _parse_variation_line(line):
+    """
+    Parse one homo_sapiens_variation.txt data line (tab-delimited, 14
+    columns; see the file's own header for the full column list). Returns
+    None for blank/malformed lines.
+    """
+    line = line.rstrip("\n")
+    if not line:
+        return None
+    cols = line.split("\t")
+    if len(cols) < 10:
+        return None
+    return {
+        "source_db_id": cols[3],
+        "clinical_significance": cols[5],
+        "phenotype_disease": cols[6],
+        "phenotype_disease_source": cols[7],
+        "coordinate": cols[9],
+    }
+
+
+def parse_variation(lines):
+    """Parse homo_sapiens_variation.txt(.gz) content (an iterable of lines),
+    skipping the multi-line preamble/header. Yields one dict per data row."""
+    started = False
+    for line in lines:
+        if line.startswith("___________"):
+            started = True
+            continue
+        if not started:
+            continue
+        row = _parse_variation_line(line)
+        if row:
+            yield row
+
+
+def build_variation_index(iter_rows_factory, needed_dbsnp_ids):
+    """
+    Two-pass scan over the (huge) variation file, via `iter_rows_factory`: a
+    zero-arg callable returning a fresh iterator of parsed variation rows
+    (as produced by parse_variation()) each time it's called, since this
+    needs to scan the rows twice without holding all of them in memory.
+
+    Pass 1 finds the genomic coordinate for each dbSNP id in
+    `needed_dbsnp_ids`. Pass 2 collects every row sharing one of those
+    coordinates -- regardless of that row's own source_db_id -- so a
+    variant's enrichment fields reflect everything UniProt reports at that
+    genomic position, not just the one dbSNP id that happened to link it to
+    humsavar.
+
+    Returns (dbsnp_to_coordinate, coordinate_info):
+      - dbsnp_to_coordinate: {dbsnp_id: coordinate}
+      - coordinate_info: {coordinate: {"source_db_id": set(), "clinical_significance": set(),
+                                        "phenotype_disease": set(), "phenotype_disease_source": set()}}
+    """
+    remaining = set(needed_dbsnp_ids)
+    dbsnp_to_coordinate = {}
+    for row in iter_rows_factory():
+        if not remaining:
+            break
+        if row["source_db_id"] in remaining:
+            dbsnp_to_coordinate[row["source_db_id"]] = row["coordinate"]
+            remaining.discard(row["source_db_id"])
+
+    relevant_coordinates = set(dbsnp_to_coordinate.values())
+    coordinate_info = {}
+    for row in iter_rows_factory():
+        coordinate = row["coordinate"]
+        if coordinate not in relevant_coordinates:
+            continue
+        info = coordinate_info.setdefault(coordinate, {
+            "source_db_id": set(),
+            "clinical_significance": set(),
+            "phenotype_disease": set(),
+            "phenotype_disease_source": set(),
+        })
+        info["source_db_id"].add(row["source_db_id"])
+        for key in ("clinical_significance", "phenotype_disease", "phenotype_disease_source"):
+            value = row[key]
+            if value and value != "-":
+                info[key].add(value)
+
+    return dbsnp_to_coordinate, coordinate_info
+
+
+def build_docs(humsavar_rows, dbsnp_to_coordinate, coordinate_info):
+    """
+    Yield one 'uniprot' document per humsavar row that could be resolved to a
+    genomic coordinate. Rows with no dbSNP id, or whose dbSNP id has no match
+    in the variation file, are skipped.
+    """
+    for row in humsavar_rows:
+        if not row["dbsnp_id"]:
+            continue
+        coordinate = dbsnp_to_coordinate.get(row["dbsnp_id"])
+        if not coordinate:
+            continue
+        _id = nc_coordinate_to_hgvs_id(coordinate)
+        if not _id:
+            continue
+
+        humsavar = {
+            "swiss_prot_ac": row["swiss_prot_ac"],
+            "ftid": row["ftid"],
+            "type_of_variant": row["type_of_variant"],
+        }
+        if row["disease_name"]:
+            humsavar["disease_name"] = row["disease_name"]
+
+        doc = {"_id": _id, "uniprot": {"humsavar": humsavar}}
+        info = coordinate_info.get(coordinate, {})
+        for key in ("source_db_id", "clinical_significance", "phenotype_disease", "phenotype_disease_source"):
+            values = info.get(key)
+            if values:
+                doc["uniprot"][key] = sorted(values)
+
+        yield unlist(doc)
+
+
+def load_data(data_folder, logger=None):
+    logger = logger or logging.getLogger(__name__)
+
+    humsavar_file = os.path.join(data_folder, HUMSAVAR_FILE)
+    variation_files = glob.glob(os.path.join(data_folder, VARIATION_FILE_GLOB))
+    assert len(variation_files) == 1, "Expecting exactly one file matching '%s', got: %s" % (
+        VARIATION_FILE_GLOB, variation_files)
+    variation_file = variation_files[0]
+
+    with open(humsavar_file, encoding="utf-8", errors="replace") as f:
+        humsavar_rows = list(parse_humsavar(f))
+    needed_dbsnp_ids = {row["dbsnp_id"] for row in humsavar_rows if row["dbsnp_id"]}
+    logger.info("Parsed %d humsavar.txt records (%d with a dbSNP id to resolve)" %
+                (len(humsavar_rows), len(needed_dbsnp_ids)))
+
+    def _iter_variation_file():
+        f = gzip.open(variation_file, "rt", encoding="utf-8", errors="replace")
+        try:
+            yield from parse_variation(f)
+        finally:
+            f.close()
+
+    dbsnp_to_coordinate, coordinate_info = build_variation_index(_iter_variation_file, needed_dbsnp_ids)
+    logger.info("Resolved %d/%d dbSNP ids to a genomic coordinate in '%s'" %
+                (len(dbsnp_to_coordinate), len(needed_dbsnp_ids), VARIATION_FILE_GLOB))
+
+    docs = list(build_docs(humsavar_rows, dbsnp_to_coordinate, coordinate_info))
+    logger.info("Built %d uniprot documents (%d humsavar records skipped: no dbSNP id or unresolved)" %
+                (len(docs), len(humsavar_rows) - len(docs)))
+    return docs

--- a/src/hub/dataload/sources/uniprot/uniprot_parser.py
+++ b/src/hub/dataload/sources/uniprot/uniprot_parser.py
@@ -2,8 +2,16 @@
 Loads humsavar.txt and homo_sapiens_variation.txt.gz as-is into 'uniprot'
 documents: one document per line in either file, verbatim. There is no
 deduplication, no merging of rows, and no correlation between the two files
--- each line becomes its own independent document with no computed _id
-(MongoDB assigns one automatically on insert).
+-- each line becomes its own independent document, identified by a random id
+(not a computed/genomic one).
+
+Every document needs an explicit "_id" here, even though its value carries
+no meaning: this project's MyVariantBasicStorage (see
+hub/dataload/storage.py) always looks at doc["_id"] before insert, to check
+whether it's a genomic HGVS id long enough to need shortening. Leaving "_id"
+unset (to let MongoDB assign one on insert) makes that lookup raise
+AssertionError for every document, since it runs before the insert ever
+happens.
 
 Column names already used elsewhere in this mapping are reused
 (source_db_id, clinical_significance, phenotype_disease,
@@ -14,6 +22,7 @@ own header (see _HUMSAVAR_FIELDS / _VARIATION_FIELDS below).
 import glob
 import gzip
 import os
+import uuid
 
 HUMSAVAR_FILE = "humsavar.txt"
 VARIATION_FILE_GLOB = "homo_sapiens_variation.txt.gz"
@@ -55,7 +64,7 @@ def parse_humsavar(lines):
             continue
         if len(values) == 6:
             values.append("-")
-        yield {"uniprot": dict(zip(_HUMSAVAR_FIELDS, values))}
+        yield {"_id": uuid.uuid4().hex, "uniprot": dict(zip(_HUMSAVAR_FIELDS, values))}
 
 
 def parse_variation(lines):
@@ -74,7 +83,7 @@ def parse_variation(lines):
         values = line.split("\t")
         if len(values) < len(_VARIATION_FIELDS):
             continue
-        yield {"uniprot": dict(zip(_VARIATION_FIELDS, values))}
+        yield {"_id": uuid.uuid4().hex, "uniprot": dict(zip(_VARIATION_FIELDS, values))}
 
 
 def load_data(data_folder, logger=None):

--- a/src/hub/dataload/sources/uniprot/uniprot_parser.py
+++ b/src/hub/dataload/sources/uniprot/uniprot_parser.py
@@ -1,14 +1,20 @@
 """
-Parses homo_sapiens_variation.txt.gz (see uniprot_dump.py for how it's
-fetched) into 'uniprot' myvariant.info documents.
+Parses the two UniProtKB variant files (see uniprot_dump.py for how they're
+fetched) into 'uniprot' myvariant.info documents:
 
-homo_sapiens_variation.txt.gz is a bulk protein-altering variant index (59M+
-rows, mostly dbSNP/ClinVar-sourced, one row per variant per Ensembl
-transcript/phenotype). Every unique genomic coordinate found in it becomes
-one output document, populated with whatever 'source_db_id' /
-'clinical_significance' / 'phenotype_disease' / 'phenotype_disease_source'
-values UniProt reports at that position -- every source sharing the
-coordinate (rs, RCV, or anything else), not just one.
+  - homo_sapiens_variation.txt.gz: bulk protein-altering variant index (59M+
+    rows, mostly dbSNP/ClinVar-sourced). This is the base: every unique
+    genomic coordinate found here becomes one output document, populated
+    with whatever 'source_db_id' / 'clinical_significance' /
+    'phenotype_disease' / 'phenotype_disease_source' values UniProt reports
+    at that position (every source sharing the coordinate -- rs, RCV, or
+    anything else -- not just one).
+  - humsavar.txt: manually curated missense variants, ~85K records. It has
+    no genomic coordinate of its own (only a dbSNP id), so its fields are
+    attached to a document only when one of that document's source_db_id
+    values matches a dbSNP id in humsavar.txt. Most documents (the vast
+    majority of the ~15M unique coordinates in the variation file have no
+    curated humsavar record) won't have a 'humsavar' field at all.
 
 Rows whose 'Chromosome Coordinate' isn't a recognized GRCh38 chromosome
 accession are skipped: without a genomic coordinate there is no way to build
@@ -21,6 +27,7 @@ import os
 
 from biothings.utils.dataload import unlist
 
+HUMSAVAR_FILE = "humsavar.txt"
 VARIATION_FILE_GLOB = "homo_sapiens_variation.txt.gz"
 
 # GRCh38 RefSeq chromosome accession prefix (before the version suffix) ->
@@ -46,6 +53,47 @@ def nc_coordinate_to_hgvs_id(coordinate):
     if not chrom:
         return None
     return "chr%s:%s" % (chrom, rest)
+
+
+def _parse_humsavar_line(line):
+    """
+    Parse one humsavar.txt data line (fixed-width/whitespace separated, NOT
+    tab-delimited):
+        A1BG        P04217     VAR_018369  p.His52Arg     LB/B     rs893184       -
+    Columns: gene name, Swiss-Prot AC, FTId, AA change, variant category,
+    dbSNP id, disease name (free text, may itself contain spaces).
+    Returns None for blank/malformed lines.
+    """
+    line = line.rstrip("\n")
+    if not line.strip():
+        return None
+    parts = line.split(None, 6)
+    if len(parts) < 6:
+        return None
+    _gene_name, swiss_prot_ac, ftid, _aa_change, type_of_variant, dbsnp_id = parts[:6]
+    disease_name = parts[6] if len(parts) == 7 else "-"
+    return {
+        "swiss_prot_ac": swiss_prot_ac,
+        "ftid": ftid,
+        "type_of_variant": type_of_variant,
+        "dbsnp_id": None if dbsnp_id == "-" else dbsnp_id,
+        "disease_name": None if disease_name == "-" else disease_name,
+    }
+
+
+def parse_humsavar(lines):
+    """Parse humsavar.txt content (an iterable of lines), skipping the
+    multi-line preamble/header. Yields one dict per data row."""
+    started = False
+    for line in lines:
+        if line.startswith("_________"):
+            started = True
+            continue
+        if not started:
+            continue
+        row = _parse_humsavar_line(line)
+        if row:
+            yield row
 
 
 def _parse_variation_line(line):
@@ -88,7 +136,8 @@ def build_variation_aggregate(rows):
     """
     Single pass over ALL homo_sapiens_variation.txt(.gz) rows (as produced by
     parse_variation()), aggregating every row by its genomic coordinate --
-    every coordinate found here ends up as an output document.
+    this file is the base of this source, so every coordinate found here
+    ends up as an output document, not just a pre-selected subset.
 
     Returns {coordinate: {"source_db_id": set(), "clinical_significance": set(),
                            "phenotype_disease": set(), "phenotype_disease_source": set()}}
@@ -113,10 +162,36 @@ def build_variation_aggregate(rows):
     return coordinate_info
 
 
-def build_docs(coordinate_info):
+def build_humsavar_index(humsavar_rows):
+    """
+    {dbsnp_id: [humsavar_record, ...]} -- a dbSNP id can be shared by more
+    than one humsavar record (real case: ABCA1's VAR_009147 and VAR_062487
+    both cite rs137854496, an un-cleaned-up UniProt curation duplicate), so
+    each dbSNP id maps to a list rather than a single record.
+    """
+    index = {}
+    for row in humsavar_rows:
+        if not row["dbsnp_id"]:
+            continue
+        record = {
+            "swiss_prot_ac": row["swiss_prot_ac"],
+            "ftid": row["ftid"],
+            "type_of_variant": row["type_of_variant"],
+        }
+        if row["disease_name"]:
+            record["disease_name"] = row["disease_name"]
+        index.setdefault(row["dbsnp_id"], []).append(record)
+    return index
+
+
+def build_docs(coordinate_info, humsavar_index):
     """
     Yield one 'uniprot' document per genomic coordinate in coordinate_info
     (i.e. per unique coordinate found in homo_sapiens_variation.txt.gz).
+    'humsavar' is attached only when one of the coordinate's source_db_id
+    values matches a dbSNP id in humsavar_index -- most documents won't have
+    one, since humsavar.txt (~85K records) is a small subset of all the
+    coordinates in the base file (~15M).
     """
     for coordinate, info in coordinate_info.items():
         _id = nc_coordinate_to_hgvs_id(coordinate)
@@ -128,6 +203,14 @@ def build_docs(coordinate_info):
             values = info.get(key)
             if values:
                 doc["uniprot"][key] = sorted(values)
+
+        humsavar_by_ftid = {}
+        for source_id in info["source_db_id"]:
+            for record in humsavar_index.get(source_id, []):
+                humsavar_by_ftid[record["ftid"]] = record
+        if humsavar_by_ftid:
+            records = list(humsavar_by_ftid.values())
+            doc["uniprot"]["humsavar"] = records[0] if len(records) == 1 else records
 
         yield unlist(doc)
 
@@ -141,8 +224,11 @@ def merge_docs(docs):
     insert (not an upsert), so two documents with the same _id would crash
     the whole batch with a MongoDB duplicate key error.
 
-    Groups by _id and merges each group into a single document, unioning the
-    enrichment fields across all colliding rows.
+    Groups by _id and merges each group into a single document: when more
+    than one distinct humsavar record ends up attached to the same _id,
+    'humsavar' becomes a list of records (as build_docs() already does for
+    multiple matches within one coordinate) and the enrichment fields are
+    unioned across all colliding rows.
     """
     grouped = {}
     for doc in docs:
@@ -154,6 +240,19 @@ def merge_docs(docs):
             continue
 
         merged = {"_id": _id, "uniprot": {}}
+
+        humsavar_by_ftid = {}
+        for d in group:
+            humsavar = d["uniprot"].get("humsavar")
+            if humsavar is None:
+                continue
+            records = humsavar if isinstance(humsavar, list) else [humsavar]
+            for record in records:
+                humsavar_by_ftid[record["ftid"]] = record
+        if humsavar_by_ftid:
+            records = list(humsavar_by_ftid.values())
+            merged["uniprot"]["humsavar"] = records[0] if len(records) == 1 else records
+
         for key in ("source_db_id", "clinical_significance", "phenotype_disease", "phenotype_disease_source"):
             values = set()
             for d in group:
@@ -169,18 +268,27 @@ def merge_docs(docs):
 def load_data(data_folder, logger=None):
     logger = logger or logging.getLogger(__name__)
 
+    humsavar_file = os.path.join(data_folder, HUMSAVAR_FILE)
     variation_files = glob.glob(os.path.join(data_folder, VARIATION_FILE_GLOB))
     assert len(variation_files) == 1, "Expecting exactly one file matching '%s', got: %s" % (
         VARIATION_FILE_GLOB, variation_files)
     variation_file = variation_files[0]
+
+    with open(humsavar_file, encoding="utf-8", errors="replace") as f:
+        humsavar_rows = list(parse_humsavar(f))
+    humsavar_index = build_humsavar_index(humsavar_rows)
+    logger.info("Parsed %d humsavar.txt records (%d distinct dbSNP ids)" %
+                (len(humsavar_rows), len(humsavar_index)))
 
     with gzip.open(variation_file, "rt", encoding="utf-8", errors="replace") as f:
         coordinate_info = build_variation_aggregate(parse_variation(f))
     logger.info("Aggregated %d unique genomic coordinates from '%s'" %
                 (len(coordinate_info), VARIATION_FILE_GLOB))
 
-    raw_docs = list(build_docs(coordinate_info))
-    logger.info("Built %d uniprot documents" % len(raw_docs))
+    raw_docs = list(build_docs(coordinate_info, humsavar_index))
+    with_humsavar = sum(1 for d in raw_docs if "humsavar" in d["uniprot"])
+    logger.info("Built %d uniprot documents (%d with a humsavar match)" %
+                (len(raw_docs), with_humsavar))
 
     docs = list(merge_docs(raw_docs))
     if len(docs) != len(raw_docs):

--- a/src/hub/dataload/sources/uniprot/uniprot_parser.py
+++ b/src/hub/dataload/sources/uniprot/uniprot_parser.py
@@ -213,6 +213,43 @@ def build_docs(humsavar_rows, dbsnp_to_coordinate, coordinate_info):
         yield unlist(doc)
 
 
+def merge_docs(docs):
+    """
+    build_docs() yields one document per humsavar row, but more than one
+    humsavar row can resolve to the same genomic coordinate -- e.g. dbSNP ids
+    that were later merged/deprecated in favor of a canonical rsID, with
+    UniProt's curated record still listing the older one. Storage does a
+    plain insert (not an upsert), so two documents with the same _id crash
+    the whole batch with a MongoDB duplicate key error.
+
+    Groups by _id and merges each group into a single document: when more
+    than one distinct humsavar record maps to the same _id, 'humsavar'
+    becomes a list of records (mirroring how ClinVar's parser handles the
+    analogous "more than one record per genomic position" case for its 'rcv'
+    field) and the enrichment fields are unioned across all colliding rows.
+    """
+    grouped = {}
+    for doc in docs:
+        grouped.setdefault(doc["_id"], []).append(doc)
+
+    for _id, group in grouped.items():
+        if len(group) == 1:
+            yield group[0]
+            continue
+
+        merged = {"_id": _id, "uniprot": {"humsavar": [d["uniprot"]["humsavar"] for d in group]}}
+        for key in ("source_db_id", "clinical_significance", "phenotype_disease", "phenotype_disease_source"):
+            values = set()
+            for d in group:
+                value = d["uniprot"].get(key)
+                if value is None:
+                    continue
+                values.update(value) if isinstance(value, list) else values.add(value)
+            if values:
+                merged["uniprot"][key] = sorted(values)
+        yield unlist(merged)
+
+
 def load_data(data_folder, logger=None):
     logger = logger or logging.getLogger(__name__)
 
@@ -239,7 +276,12 @@ def load_data(data_folder, logger=None):
     logger.info("Resolved %d/%d dbSNP ids to a genomic coordinate in '%s'" %
                 (len(dbsnp_to_coordinate), len(needed_dbsnp_ids), VARIATION_FILE_GLOB))
 
-    docs = list(build_docs(humsavar_rows, dbsnp_to_coordinate, coordinate_info))
+    raw_docs = list(build_docs(humsavar_rows, dbsnp_to_coordinate, coordinate_info))
     logger.info("Built %d uniprot documents (%d humsavar records skipped: no dbSNP id or unresolved)" %
-                (len(docs), len(humsavar_rows) - len(docs)))
+                (len(raw_docs), len(humsavar_rows) - len(raw_docs)))
+
+    docs = list(merge_docs(raw_docs))
+    if len(docs) != len(raw_docs):
+        logger.info("Merged %d colliding documents sharing an _id down to %d" %
+                    (len(raw_docs), len(docs)))
     return docs

--- a/src/hub/dataload/sources/uniprot/uniprot_parser.py
+++ b/src/hub/dataload/sources/uniprot/uniprot_parser.py
@@ -2,21 +2,23 @@
 Parses the two UniProtKB variant files (see uniprot_dump.py for how they're
 fetched) into 'uniprot' myvariant.info documents:
 
-  - humsavar.txt: manually curated missense variants. This drives which
-    variants end up in this source -- every output document corresponds to
-    exactly one humsavar.txt record.
   - homo_sapiens_variation.txt.gz: bulk protein-altering variant index (59M+
-    rows, mostly dbSNP/ClinVar-sourced). humsavar.txt has no genomic
-    coordinate of its own (only a dbSNP id), so this file is used purely to
-    look up that coordinate and to enrich the record with whatever
-    'source_db_id' / 'clinical_significance' / 'phenotype_disease' /
-    'phenotype_disease_source' values UniProt reports at that genomic
-    position -- not just the one dbSNP id humsavar happens to reference, but
-    every source (rs, RCV, or anything else) sharing that same coordinate.
+    rows, mostly dbSNP/ClinVar-sourced). This is the base: every unique
+    genomic coordinate found here becomes one output document, populated
+    with whatever 'source_db_id' / 'clinical_significance' /
+    'phenotype_disease' / 'phenotype_disease_source' values UniProt reports
+    at that position (every source sharing the coordinate -- rs, RCV, or
+    anything else -- not just one).
+  - humsavar.txt: manually curated missense variants, ~85K records. It has
+    no genomic coordinate of its own (only a dbSNP id), so its fields are
+    attached to a document only when one of that document's source_db_id
+    values matches a dbSNP id in humsavar.txt. Most documents (the vast
+    majority of the ~15M unique coordinates in the variation file have no
+    curated humsavar record) won't have a 'humsavar' field at all.
 
-humsavar.txt records with no dbSNP id, or whose dbSNP id can't be found in
-homo_sapiens_variation.txt.gz, are skipped: without a genomic coordinate there
-is no way to build the 'chrN:g.posREF>ALT' _id myvariant.info requires.
+Rows whose 'Chromosome Coordinate' isn't a recognized GRCh38 chromosome
+accession are skipped: without a genomic coordinate there is no way to build
+the 'chrN:g.posREF>ALT' _id myvariant.info requires.
 """
 import glob
 import gzip
@@ -130,103 +132,103 @@ def parse_variation(lines):
             yield row
 
 
-def build_variation_index(iter_rows_factory, needed_dbsnp_ids):
+def build_variation_aggregate(rows):
     """
-    Two-pass scan over the (huge) variation file, via `iter_rows_factory`: a
-    zero-arg callable returning a fresh iterator of parsed variation rows
-    (as produced by parse_variation()) each time it's called, since this
-    needs to scan the rows twice without holding all of them in memory.
+    Single pass over ALL homo_sapiens_variation.txt(.gz) rows (as produced by
+    parse_variation()), aggregating every row by its genomic coordinate --
+    this file is the base of this source, so every coordinate found here
+    ends up as an output document, not just a pre-selected subset.
 
-    Pass 1 finds the genomic coordinate for each dbSNP id in
-    `needed_dbsnp_ids`. Pass 2 collects every row sharing one of those
-    coordinates -- regardless of that row's own source_db_id -- so a
-    variant's enrichment fields reflect everything UniProt reports at that
-    genomic position, not just the one dbSNP id that happened to link it to
-    humsavar.
-
-    Returns (dbsnp_to_coordinate, coordinate_info):
-      - dbsnp_to_coordinate: {dbsnp_id: coordinate}
-      - coordinate_info: {coordinate: {"source_db_id": set(), "clinical_significance": set(),
-                                        "phenotype_disease": set(), "phenotype_disease_source": set()}}
+    Returns {coordinate: {"source_db_id": set(), "clinical_significance": set(),
+                           "phenotype_disease": set(), "phenotype_disease_source": set()}}
     """
-    remaining = set(needed_dbsnp_ids)
-    dbsnp_to_coordinate = {}
-    for row in iter_rows_factory():
-        if not remaining:
-            break
-        if row["source_db_id"] in remaining:
-            dbsnp_to_coordinate[row["source_db_id"]] = row["coordinate"]
-            remaining.discard(row["source_db_id"])
-
-    relevant_coordinates = set(dbsnp_to_coordinate.values())
     coordinate_info = {}
-    for row in iter_rows_factory():
+    for row in rows:
         coordinate = row["coordinate"]
-        if coordinate not in relevant_coordinates:
-            continue
-        info = coordinate_info.setdefault(coordinate, {
-            "source_db_id": set(),
-            "clinical_significance": set(),
-            "phenotype_disease": set(),
-            "phenotype_disease_source": set(),
-        })
+        info = coordinate_info.get(coordinate)
+        if info is None:
+            info = {
+                "source_db_id": set(),
+                "clinical_significance": set(),
+                "phenotype_disease": set(),
+                "phenotype_disease_source": set(),
+            }
+            coordinate_info[coordinate] = info
         info["source_db_id"].add(row["source_db_id"])
         for key in ("clinical_significance", "phenotype_disease", "phenotype_disease_source"):
             value = row[key]
             if value and value != "-":
                 info[key].add(value)
+    return coordinate_info
 
-    return dbsnp_to_coordinate, coordinate_info
 
-
-def build_docs(humsavar_rows, dbsnp_to_coordinate, coordinate_info):
+def build_humsavar_index(humsavar_rows):
     """
-    Yield one 'uniprot' document per humsavar row that could be resolved to a
-    genomic coordinate. Rows with no dbSNP id, or whose dbSNP id has no match
-    in the variation file, are skipped.
+    {dbsnp_id: [humsavar_record, ...]} -- a dbSNP id can be shared by more
+    than one humsavar record (real case: ABCA1's VAR_009147 and VAR_062487
+    both cite rs137854496, an un-cleaned-up UniProt curation duplicate), so
+    each dbSNP id maps to a list rather than a single record.
     """
+    index = {}
     for row in humsavar_rows:
         if not row["dbsnp_id"]:
             continue
-        coordinate = dbsnp_to_coordinate.get(row["dbsnp_id"])
-        if not coordinate:
-            continue
-        _id = nc_coordinate_to_hgvs_id(coordinate)
-        if not _id:
-            continue
-
-        humsavar = {
+        record = {
             "swiss_prot_ac": row["swiss_prot_ac"],
             "ftid": row["ftid"],
             "type_of_variant": row["type_of_variant"],
         }
         if row["disease_name"]:
-            humsavar["disease_name"] = row["disease_name"]
+            record["disease_name"] = row["disease_name"]
+        index.setdefault(row["dbsnp_id"], []).append(record)
+    return index
 
-        doc = {"_id": _id, "uniprot": {"humsavar": humsavar}}
-        info = coordinate_info.get(coordinate, {})
+
+def build_docs(coordinate_info, humsavar_index):
+    """
+    Yield one 'uniprot' document per genomic coordinate in coordinate_info
+    (i.e. per unique coordinate found in homo_sapiens_variation.txt.gz).
+    'humsavar' is attached only when one of the coordinate's source_db_id
+    values matches a dbSNP id in humsavar_index -- most documents won't have
+    one, since humsavar.txt (~85K records) is a small subset of all the
+    coordinates in the base file (~15M).
+    """
+    for coordinate, info in coordinate_info.items():
+        _id = nc_coordinate_to_hgvs_id(coordinate)
+        if not _id:
+            continue
+
+        doc = {"_id": _id, "uniprot": {}}
         for key in ("source_db_id", "clinical_significance", "phenotype_disease", "phenotype_disease_source"):
             values = info.get(key)
             if values:
                 doc["uniprot"][key] = sorted(values)
+
+        humsavar_by_ftid = {}
+        for source_id in info["source_db_id"]:
+            for record in humsavar_index.get(source_id, []):
+                humsavar_by_ftid[record["ftid"]] = record
+        if humsavar_by_ftid:
+            records = list(humsavar_by_ftid.values())
+            doc["uniprot"]["humsavar"] = records[0] if len(records) == 1 else records
 
         yield unlist(doc)
 
 
 def merge_docs(docs):
     """
-    build_docs() yields one document per humsavar row, but more than one
-    humsavar row can resolve to the same genomic coordinate -- e.g. dbSNP ids
-    that were later merged/deprecated in favor of a canonical rsID, with
-    UniProt's curated record still listing the older one. Storage does a
-    plain insert (not an upsert), so two documents with the same _id crash
+    Two distinct raw 'Chromosome Coordinate' strings can normalize to the
+    same _id (e.g. differing only by RefSeq patch version), so build_docs()
+    can still yield more than one document for the same _id even though it
+    iterates coordinate_info's already-unique keys. Storage does a plain
+    insert (not an upsert), so two documents with the same _id would crash
     the whole batch with a MongoDB duplicate key error.
 
     Groups by _id and merges each group into a single document: when more
-    than one distinct humsavar record maps to the same _id, 'humsavar'
-    becomes a list of records (mirroring how ClinVar's parser handles the
-    analogous "more than one record per genomic position" case for its 'rcv'
-    field) and the enrichment fields are unioned across all colliding rows.
+    than one distinct humsavar record ends up attached to the same _id,
+    'humsavar' becomes a list of records (as build_docs() already does for
+    multiple matches within one coordinate) and the enrichment fields are
+    unioned across all colliding rows.
     """
     grouped = {}
     for doc in docs:
@@ -237,7 +239,20 @@ def merge_docs(docs):
             yield group[0]
             continue
 
-        merged = {"_id": _id, "uniprot": {"humsavar": [d["uniprot"]["humsavar"] for d in group]}}
+        merged = {"_id": _id, "uniprot": {}}
+
+        humsavar_by_ftid = {}
+        for d in group:
+            humsavar = d["uniprot"].get("humsavar")
+            if humsavar is None:
+                continue
+            records = humsavar if isinstance(humsavar, list) else [humsavar]
+            for record in records:
+                humsavar_by_ftid[record["ftid"]] = record
+        if humsavar_by_ftid:
+            records = list(humsavar_by_ftid.values())
+            merged["uniprot"]["humsavar"] = records[0] if len(records) == 1 else records
+
         for key in ("source_db_id", "clinical_significance", "phenotype_disease", "phenotype_disease_source"):
             values = set()
             for d in group:
@@ -261,24 +276,19 @@ def load_data(data_folder, logger=None):
 
     with open(humsavar_file, encoding="utf-8", errors="replace") as f:
         humsavar_rows = list(parse_humsavar(f))
-    needed_dbsnp_ids = {row["dbsnp_id"] for row in humsavar_rows if row["dbsnp_id"]}
-    logger.info("Parsed %d humsavar.txt records (%d with a dbSNP id to resolve)" %
-                (len(humsavar_rows), len(needed_dbsnp_ids)))
+    humsavar_index = build_humsavar_index(humsavar_rows)
+    logger.info("Parsed %d humsavar.txt records (%d distinct dbSNP ids)" %
+                (len(humsavar_rows), len(humsavar_index)))
 
-    def _iter_variation_file():
-        f = gzip.open(variation_file, "rt", encoding="utf-8", errors="replace")
-        try:
-            yield from parse_variation(f)
-        finally:
-            f.close()
+    with gzip.open(variation_file, "rt", encoding="utf-8", errors="replace") as f:
+        coordinate_info = build_variation_aggregate(parse_variation(f))
+    logger.info("Aggregated %d unique genomic coordinates from '%s'" %
+                (len(coordinate_info), VARIATION_FILE_GLOB))
 
-    dbsnp_to_coordinate, coordinate_info = build_variation_index(_iter_variation_file, needed_dbsnp_ids)
-    logger.info("Resolved %d/%d dbSNP ids to a genomic coordinate in '%s'" %
-                (len(dbsnp_to_coordinate), len(needed_dbsnp_ids), VARIATION_FILE_GLOB))
-
-    raw_docs = list(build_docs(humsavar_rows, dbsnp_to_coordinate, coordinate_info))
-    logger.info("Built %d uniprot documents (%d humsavar records skipped: no dbSNP id or unresolved)" %
-                (len(raw_docs), len(humsavar_rows) - len(raw_docs)))
+    raw_docs = list(build_docs(coordinate_info, humsavar_index))
+    with_humsavar = sum(1 for d in raw_docs if "humsavar" in d["uniprot"])
+    logger.info("Built %d uniprot documents (%d with a humsavar match)" %
+                (len(raw_docs), with_humsavar))
 
     docs = list(merge_docs(raw_docs))
     if len(docs) != len(raw_docs):

--- a/src/hub/dataload/sources/uniprot/uniprot_upload.py
+++ b/src/hub/dataload/sources/uniprot/uniprot_upload.py
@@ -1,7 +1,7 @@
-import biothings.hub.dataload.uploader as uploader
 from hub.dataload.uploader import SnpeffPostUpdateUploader
+from hub.dataload.sources.uniprot import uniprot_parser
 
-class UniprotUploader(uploader.DummySourceUploader,SnpeffPostUpdateUploader):
+class UniprotUploader(SnpeffPostUpdateUploader):
 
     name = "uniprot"
     __metadata__ = {
@@ -14,6 +14,10 @@ class UniprotUploader(uploader.DummySourceUploader,SnpeffPostUpdateUploader):
             "license_url_short": "http://bit.ly/2RMp2Wa"
         }
     }
+
+    def load_data(self, data_folder):
+        self.logger.info("Load data from folder '%s'" % data_folder)
+        return uniprot_parser.load_data(data_folder, logger=self.logger)
 
     @classmethod
     def get_mapping(klass):

--- a/src/hub/dataload/sources/uniprot/uniprot_upload.py
+++ b/src/hub/dataload/sources/uniprot/uniprot_upload.py
@@ -24,7 +24,23 @@ class UniprotUploader(SnpeffPostUpdateUploader):
         mapping = {
             "uniprot": {
                 "properties": {
+                    "gene_name": {
+                        "type": "text",
+                        "analyzer": "string_lowercase"
+                    },
+                    "swiss_prot_ac": {
+                        "type": "text",
+                        "analyzer": "string_lowercase"
+                    },
+                    "aa_change": {
+                        "type": "text",
+                        "analyzer": "string_lowercase"
+                    },
                     "source_db_id": {
+                        "type": "text",
+                        "analyzer": "string_lowercase"
+                    },
+                    "consequence_type": {
                         "type": "text",
                         "analyzer": "string_lowercase"
                     },
@@ -38,14 +54,42 @@ class UniprotUploader(SnpeffPostUpdateUploader):
                         "type": "text",
                         "analyzer": "string_lowercase"
                     },
+                    "cytogenetic_band": {
+                        "type": "text",
+                        "analyzer": "string_lowercase"
+                    },
+                    "ensembl_gene_id": {
+                        "type": "text",
+                        "analyzer": "string_lowercase"
+                    },
+                    "ensembl_transcript_id": {
+                        "type": "text",
+                        "analyzer": "string_lowercase"
+                    },
+                    "ensembl_translation_id": {
+                        "type": "text",
+                        "analyzer": "string_lowercase"
+                    },
+                    "evidence": {
+                        "type": "text",
+                        "analyzer": "string_lowercase"
+                    },
                     "humsavar": {
                         "properties": {
+                            "gene_name": {
+                                "type": "text",
+                                "analyzer": "string_lowercase"
+                            },
                             "swiss_prot_ac": {
                                 "type": "text",
                                 "analyzer": "string_lowercase"
                             },
                             "ftid": {
                                 "copy_to" : ["all"],
+                                "type": "text",
+                                "analyzer": "string_lowercase"
+                            },
+                            "aa_change": {
                                 "type": "text",
                                 "analyzer": "string_lowercase"
                             },
@@ -62,4 +106,3 @@ class UniprotUploader(SnpeffPostUpdateUploader):
             }
         }
         return mapping
-

--- a/src/tests/data/test_dbnsfp_parser_54a.py
+++ b/src/tests/data/test_dbnsfp_parser_54a.py
@@ -1,0 +1,278 @@
+"""
+Unit tests for the dbNSFP 5.4a parser (v1 and v2).
+
+Scope, relative to the previously-implemented 5.3.1a parser (see
+test_dbnsfp_parser_531a.py, which remains as-is and still passes against the
+531a parser - none of its assertions changed underneath it):
+
+  - VALID_COLUMN_NO (508), matching the real dbNSFP 5.4a variant file
+    (505 in 5.3.1a + 3 new GPN-MSA columns).
+  - GPN-MSA: 3 new columns (GPN_MSA_score, GPN_MSA_converted_rankscore,
+    GPN_MSA_pred), new in dbNSFP 5.4. Not per-transcript (same category as
+    ESM1b/AlphaMissense/popEVE), so v2 keeps it top-level, not under "protein".
+  - Ensembl_canonical: renamed from VEP_canonical in dbNSFP 5.4 (same meaning -
+    canonical transcript designation, provided by Gencode/Ensembl). v1 keeps
+    it top-level (dest "ensembl_canonical"); v2 keeps it per-transcript, under
+    "protein" (dest "protein.ensembl_canonical"), same placement VEP_canonical
+    had.
+  - Everything else carried over unchanged from 5.3.1a: hs1 handling, the
+    fields added/renamed across 5.0-5.3.1 (MANE, MutationTaster2021, MutPred2,
+    MisFit, GERP_92_mammals, ESM1b_converted_rankscore, dbNSFP_POPMAX,
+    popEVE), and the issue #179 multi-transcript merge divergence between v1
+    and v2.
+"""
+import os
+import sys
+import unittest
+import importlib.util
+
+# Ensure src/ is on the path so hub modules are importable
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+
+def _load_parser(filename, modname):
+    """Load a dbnsfp parser module directly, bypassing biothings hub init."""
+    path = os.path.join(
+        os.path.dirname(__file__),
+        "..", "..", "hub", "dataload", "sources", "dbnsfp", filename,
+    )
+    spec = importlib.util.spec_from_file_location(modname, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+V1 = _load_parser("dbnsfp_parser_54a_v1.py", "dbnsfp_parser_54a_v1")
+V2 = _load_parser("dbnsfp_parser_54a_v2.py", "dbnsfp_parser_54a_v2")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _base_row(mod):
+    """A row with every column NA ('.') plus a fixed, valid hg19/hg38 position."""
+    row = {col.name: "." for col in mod.COLUMNS}
+    row.update({
+        "#chr": "1", "pos(1-based)": "100", "ref": "A", "alt": "G",
+        "hg19_chr": "1", "hg19_pos(1-based)": "50",
+    })
+    return row
+
+
+# ---------------------------------------------------------------------------
+# VALID_COLUMN_NO
+# ---------------------------------------------------------------------------
+
+class TestValidColumnNumber(unittest.TestCase):
+    """508 is the real column count of the dbNSFP5.4a_variant.chr<#> files (505 + 3 GPN-MSA)."""
+
+    def test_v1_column_count(self):
+        self.assertEqual(V1.VALID_COLUMN_NO, 508)
+
+    def test_v2_column_count(self):
+        self.assertEqual(V2.VALID_COLUMN_NO, 508)
+
+
+# ---------------------------------------------------------------------------
+# GPN-MSA (new in dbNSFP 5.4)
+# ---------------------------------------------------------------------------
+
+class TestGpnMsa(unittest.TestCase):
+
+    def test_v1_gpn_msa(self):
+        row = _base_row(V1)
+        row.update({"GPN_MSA_score": "-8.5", "GPN_MSA_converted_rankscore": "0.9", "GPN_MSA_pred": "D"})
+        doc = V1.construct_hg38_doc(row)
+        self.assertEqual(doc["dbnsfp"]["gpn_msa"], {"score": -8.5, "converted_rankscore": 0.9, "pred": "D"})
+
+    def test_v2_gpn_msa_is_not_per_transcript(self):
+        """Unlike SIFT/REVEL/etc., GPN-MSA isn't tied to a specific transcript, so it
+        stays top-level in v2 rather than nested under the per-transcript 'protein' list."""
+        row = _base_row(V2)
+        row.update({
+            "GPN_MSA_score": "-8.5", "GPN_MSA_converted_rankscore": "0.9", "GPN_MSA_pred": "D",
+            "Ensembl_transcriptid": "ENST00000001",
+        })
+        doc = V2.construct_hg38_doc(row)
+        self.assertEqual(doc["dbnsfp"]["gpn_msa"], {"score": -8.5, "converted_rankscore": 0.9, "pred": "D"})
+        protein = doc["dbnsfp"]["protein"]
+        protein = protein if isinstance(protein, list) else [protein]
+        for entry in protein:
+            self.assertNotIn("gpn_msa", entry)
+
+    def test_missing_gpn_msa_is_simply_absent(self):
+        for mod in (V1, V2):
+            row = _base_row(mod)
+            doc = mod.construct_hg38_doc(row)
+            self.assertNotIn("gpn_msa", doc["dbnsfp"])
+
+
+# ---------------------------------------------------------------------------
+# Ensembl_canonical (renamed from VEP_canonical in dbNSFP 5.4)
+# ---------------------------------------------------------------------------
+
+class TestEnsemblCanonical(unittest.TestCase):
+
+    def test_vep_canonical_is_gone(self):
+        for mod in (V1, V2):
+            self.assertNotIn("VEP_canonical", {c.name for c in mod.COLUMNS})
+            self.assertIn("Ensembl_canonical", {c.name for c in mod.COLUMNS})
+
+    def test_v1_ensembl_canonical(self):
+        row = _base_row(V1)
+        row["Ensembl_canonical"] = "1"
+        doc = V1.construct_hg38_doc(row)
+        self.assertEqual(doc["dbnsfp"]["ensembl_canonical"], "1")
+
+    def test_v2_ensembl_canonical_is_per_transcript(self):
+        """Same placement VEP_canonical had: per-transcript, nested under the protein list."""
+        row = _base_row(V2)
+        row["Ensembl_canonical"] = "1"
+        row["Ensembl_transcriptid"] = "ENST00000001"
+        doc = V2.construct_hg38_doc(row)
+        self.assertEqual(doc["dbnsfp"]["protein"][0]["ensembl_canonical"], "1")
+
+
+# ---------------------------------------------------------------------------
+# Fields carried over from 5.3.1a - unaffected by the 5.4a bump, spot-checked
+# here so this file alone documents 54a's actual (not just delta) behavior.
+# ---------------------------------------------------------------------------
+
+class TestFieldsCarriedOverFrom531a(unittest.TestCase):
+
+    def test_v1_hs1_present_on_both_assemblies(self):
+        row = _base_row(V1)
+        row["hs1_pos(1-based)"] = "200"
+        hg19_doc = V1.construct_hg19_doc(row)
+        hg38_doc = V1.construct_hg38_doc(row)
+        expected = {"start": 200, "end": 200}
+        self.assertEqual(hg19_doc["dbnsfp"]["hs1"], expected)
+        self.assertEqual(hg38_doc["dbnsfp"]["hs1"], expected)
+
+    def test_v1_mane(self):
+        row = _base_row(V1)
+        row["MANE"] = "Select"
+        doc = V1.construct_hg38_doc(row)
+        self.assertEqual(doc["dbnsfp"]["mane"], "Select")
+
+    def test_v1_mutpred2_replaces_mutpred_v1(self):
+        row = _base_row(V1)
+        row.update({
+            "MutPred2_score": "0.8", "MutPred2_rankscore": "0.7", "MutPred2_pred": "PS",
+            "MutPred2_top5_mechanisms": "Loss of helix (P = 0.0444)",
+        })
+        doc = V1.construct_hg38_doc(row)
+        mp2 = doc["dbnsfp"]["mutpred2"]
+        self.assertEqual(mp2["score"], 0.8)
+        self.assertEqual(mp2["pred"], "PS")
+        self.assertEqual(mp2["mechanisms"], {"mechanism": "Loss of helix", "p_val": 0.0444})
+
+    def test_v1_misfit_scores(self):
+        row = _base_row(V1)
+        row.update({
+            "MisFit_D_score": "0.5", "MisFit_D_rankscore": "0.4",
+            "MisFit_D_pred_lenient": "D", "MisFit_D_pred_stringent": "T",
+            "MisFit_S_score": "0.01", "MisFit_S_rankscore": "0.3",
+        })
+        doc = V1.construct_hg38_doc(row)
+        misfit = doc["dbnsfp"]["misfit"]
+        self.assertEqual(misfit["d"], {"score": 0.5, "rankscore": 0.4, "pred_lenient": "D", "pred_stringent": "T"})
+        self.assertEqual(misfit["s"], {"score": 0.01, "rankscore": 0.3})
+
+    def test_v1_gerp_92_mammals(self):
+        row = _base_row(V1)
+        row.update({"GERP_92_mammals": "3.5", "GERP_92_mammals_rankscore": "0.6"})
+        doc = V1.construct_hg38_doc(row)
+        self.assertEqual(doc["dbnsfp"]["gerp"]["92_mammals"], {"score": 3.5, "rankscore": 0.6})
+
+    def test_v1_esm1b_converted_rankscore(self):
+        row = _base_row(V1)
+        row.update({"ESM1b_score": "-5.0", "ESM1b_converted_rankscore": "0.77", "ESM1b_pred": "D"})
+        doc = V1.construct_hg38_doc(row)
+        self.assertEqual(doc["dbnsfp"]["esm1b"]["converted_rankscore"], 0.77)
+
+    def test_v1_dbnsfp_popmax(self):
+        row = _base_row(V1)
+        row.update({"dbNSFP_POPMAX_AF": "0.01", "dbNSFP_POPMAX_AC": "12", "dbNSFP_POPMAX_POP": "AFR"})
+        doc = V1.construct_hg38_doc(row)
+        self.assertEqual(doc["dbnsfp"]["dbnsfp_popmax"], {"af": 0.01, "ac": 12, "pop": "AFR"})
+
+    def test_v1_popeve(self):
+        row = _base_row(V1)
+        row.update({"popEVE_score": "-6.2", "popEVE_pred": "S", "popEVE_converted_rankscore": "0.9"})
+        doc = V1.construct_hg38_doc(row)
+        self.assertEqual(doc["dbnsfp"]["popeve"], {"score": -6.2, "pred": "S", "converted_rankscore": 0.9})
+
+    def test_v2_mutationtaster_2021_model_via_analysis(self):
+        row = _base_row(V2)
+        row.update({
+            "MutationTaster_score": "1", "MutationTaster_rankscore": "0.9",
+            "MutationTaster_pred": "D", "MutationTaster_model": "simple_aae",
+            "MutationTaster_trees_benign": "0", "MutationTaster_trees_deleterious": "100",
+        })
+        doc = V2.construct_hg38_doc(row)
+        mt = doc["dbnsfp"]["mutationtaster"]
+        self.assertEqual(mt["rankscore"], 0.9)
+        self.assertEqual(mt["analysis"]["trees_benign"], 0)
+        self.assertEqual(mt["analysis"]["trees_deleterious"], 100)
+
+
+# ---------------------------------------------------------------------------
+# Multi-transcript merge regression (issue #179), re-run for 5.4a
+# ---------------------------------------------------------------------------
+
+class TestMultiTranscriptRevelMergeRegression(unittest.TestCase):
+    """
+    Confirms the version bump to 5.4a did not change the known divergence
+    between v1 and v2 when the same variant has multiple transcript rows:
+
+      - v1's load_file() merge only extends the `aa` field; every other
+        per-transcript value (e.g. REVEL) from row 2+ is still discarded.
+      - v2's load_file() merge extends the `protein` list, so every
+        transcript's REVEL score is preserved.
+    """
+
+    @staticmethod
+    def _two_transcript_rows(mod):
+        common = {
+            "#chr": "X", "pos(1-based)": "153693944", "ref": "C", "alt": "A",
+            "hg19_chr": "X", "hg19_pos(1-based)": "152959399",
+            "aaref": "H", "aaalt": "Q",
+        }
+        rows = []
+        for transcriptid, revel_score in (("ENST00000457723", 0.173), ("ENST00000611849", 0.653)):
+            row = _base_row(mod)
+            row.update(common)
+            row.update({"Ensembl_transcriptid": transcriptid, "REVEL_score": str(revel_score)})
+            rows.append(row)
+        return rows
+
+    def test_v1_still_discards_revel_from_second_transcript(self):
+        rows = self._two_transcript_rows(V1)
+        docs = [V1.construct_hg38_doc(r) for r in rows]
+        self.assertEqual(docs[0]["_id"], docs[1]["_id"])
+
+        last_doc = docs[0]
+        last_aa = [last_doc["dbnsfp"]["aa"]]
+        last_aa.append(docs[1]["dbnsfp"]["aa"])
+        last_doc["dbnsfp"]["aa"] = last_aa
+
+        self.assertEqual(len(last_doc["dbnsfp"]["aa"]), 2)
+        self.assertEqual(last_doc["dbnsfp"]["revel"]["score"], 0.173)
+
+    def test_v2_preserves_revel_from_both_transcripts(self):
+        rows = self._two_transcript_rows(V2)
+        docs = [V2.construct_hg38_doc(r) for r in rows]
+        self.assertEqual(docs[0]["_id"], docs[1]["_id"])
+
+        merged_protein = docs[0]["dbnsfp"]["protein"] + docs[1]["dbnsfp"]["protein"]
+
+        revel_scores = [p["revel"]["score"] for p in merged_protein if "revel" in p]
+        self.assertIn(0.173, revel_scores)
+        self.assertIn(0.653, revel_scores)
+        self.assertEqual(len(merged_protein), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tests/data/test_uniprot_parser.py
+++ b/src/tests/data/test_uniprot_parser.py
@@ -1,22 +1,23 @@
 """
 Unit tests for the 'uniprot' myvariant.info source parser.
 
-Background: humsavar.txt (manually curated missense variants) has no genomic
-coordinate of its own -- only a dbSNP id -- so it's enriched by looking up
-that dbSNP id in the much larger homo_sapiens_variation.txt.gz variant index,
-which does carry a genomic coordinate. Per-source decisions this parser
-implements (see conversation / commit history for the "why"):
+Architecture (per direct decision from the source owner, overriding an
+earlier humsavar-driven design): homo_sapiens_variation.txt.gz is the base --
+every unique genomic coordinate found there becomes one output document,
+enriched with whatever source_db_id/clinical_significance/phenotype_disease/
+phenotype_disease_source values UniProt reports at that position. humsavar.txt
+(~85K manually curated records, vs. ~15M coordinates in the base file) is
+attached on top, only when available: a document gets a 'humsavar' field only
+if one of its source_db_id values matches a dbSNP id humsavar.txt references.
+Most documents won't have one.
 
-  1. humsavar.txt drives which variants are produced; it's enriched with
-     whatever homo_sapiens_variation.txt.gz reports at the matched genomic
-     position -- including rs (dbSNP), RCV (ClinVar) or any other source,
-     not just the one dbSNP id used to find that position.
-  2. humsavar.txt's variant-category vocabulary (now ACMG/AMP-style: LP/P,
-     LB/B, US) is stored as-is, not translated to the old Disease/
-     Polymorphism/Unclassified scheme.
-  3. No new fields (e.g. Evidence, Consequence Type) are added to the
-     existing mapping -- only source_db_id, clinical_significance,
-     phenotype_disease, phenotype_disease_source and the humsavar.* fields.
+Other standing decisions this parser implements:
+  - humsavar.txt's variant-category vocabulary (now ACMG/AMP-style: LP/P,
+    LB/B, US) is stored as-is, not translated to the old Disease/
+    Polymorphism/Unclassified scheme.
+  - No new fields (e.g. Evidence, Consequence Type) are added to the
+    existing mapping -- only source_db_id, clinical_significance,
+    phenotype_disease, phenotype_disease_source and the humsavar.* fields.
 """
 import os
 import sys
@@ -116,7 +117,7 @@ class TestParseHumsavar(unittest.TestCase):
         self.assertIsNone(row["disease_name"])
 
     def test_new_acmg_vocabulary_kept_as_is(self):
-        """Decision 2: the current LP/P/LB/B/US vocabulary is not translated."""
+        """Standing decision: the current LP/P/LB/B/US vocabulary is not translated."""
         lines = _HUMSAVAR_PREAMBLE + [
             "AAAS        Q9NRG9     VAR_012804  p.Gln15Lys     LP/P     rs121918549    "
             "Achalasia-addisonianism-alacrima syndrome (AAAS) [MIM:231550]\n",
@@ -197,16 +198,15 @@ class TestParseVariation(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# build_variation_index
+# build_variation_aggregate
 # ---------------------------------------------------------------------------
 
-class TestBuildVariationIndex(unittest.TestCase):
+class TestBuildVariationAggregate(unittest.TestCase):
     """
     Grounded in a real record found in UniProt's current release: the NSRP1
     variant p.Lys30Glu (chr17:g.30178149A>G) is reported by three different
     sources at the exact same genomic coordinate: rs143842750 (dbSNP),
-    RCV004292335 and RCV004545615 (ClinVar) -- exactly the "rs and RCV and any
-    other one" case Decision 1 calls for.
+    RCV004292335 and RCV004545615 (ClinVar).
     """
 
     def setUp(self):
@@ -218,51 +218,83 @@ class TestBuildVariationIndex(unittest.TestCase):
             {"source_db_id": "RCV004545615", "coordinate": "NC_000017.11:g.30178149A>G",
              "clinical_significance": "Likely benign", "phenotype_disease": "NSRP1-related disorder",
              "phenotype_disease_source": "RCV004545615"},
-            # unrelated variant elsewhere in the file -- must never leak into the index
-            {"source_db_id": "rs000000001", "coordinate": "NC_000001.11:g.111A>G",
-             "clinical_significance": "-", "phenotype_disease": "-", "phenotype_disease_source": "-"},
+            # a wholly unrelated coordinate, to prove aggregation doesn't cross-contaminate
+            "SENTINEL",
         ]
+        self.rows[-1] = {"source_db_id": "rs000000001", "coordinate": "NC_000001.11:g.111A>G",
+                          "clinical_significance": "-", "phenotype_disease": "-", "phenotype_disease_source": "-"}
 
-    def _factory(self):
-        return lambda: iter(self.rows)
+    def test_every_coordinate_becomes_a_key(self):
+        """Unlike the old humsavar-driven design, ALL coordinates are aggregated,
+        not just a pre-selected subset -- this is the base file now."""
+        coordinate_info = up.build_variation_aggregate(self.rows)
+        self.assertEqual(set(coordinate_info.keys()), {
+            "NC_000017.11:g.30178149A>G", "NC_000001.11:g.111A>G",
+        })
 
-    def test_resolves_needed_dbsnp_id_to_coordinate(self):
-        dbsnp_to_coord, _ = up.build_variation_index(self._factory(), {"rs143842750"})
-        self.assertEqual(dbsnp_to_coord["rs143842750"], "NC_000017.11:g.30178149A>G")
-
-    def test_unneeded_dbsnp_id_not_resolved(self):
-        dbsnp_to_coord, _ = up.build_variation_index(self._factory(), {"rs143842750"})
-        self.assertNotIn("rs000000001", dbsnp_to_coord)
-
-    def test_unknown_dbsnp_id_absent_from_result(self):
-        dbsnp_to_coord, _ = up.build_variation_index(self._factory(), {"rs_not_in_file"})
-        self.assertNotIn("rs_not_in_file", dbsnp_to_coord)
-
-    def test_aggregates_all_source_db_ids_sharing_the_coordinate(self):
-        """Decision 1: include rs, RCV, and any other source_db_id at that position."""
-        _, coord_info = up.build_variation_index(self._factory(), {"rs143842750"})
-        info = coord_info["NC_000017.11:g.30178149A>G"]
+    def test_aggregates_all_source_db_ids_sharing_a_coordinate(self):
+        coordinate_info = up.build_variation_aggregate(self.rows)
+        info = coordinate_info["NC_000017.11:g.30178149A>G"]
         self.assertEqual(info["source_db_id"],
                           {"rs143842750", "RCV004292335", "RCV004545615"})
 
     def test_aggregates_clinical_and_phenotype_fields(self):
-        _, coord_info = up.build_variation_index(self._factory(), {"rs143842750"})
-        info = coord_info["NC_000017.11:g.30178149A>G"]
+        coordinate_info = up.build_variation_aggregate(self.rows)
+        info = coordinate_info["NC_000017.11:g.30178149A>G"]
         self.assertEqual(info["clinical_significance"], {"Likely benign"})
         self.assertEqual(info["phenotype_disease"], {"NSRP1-related disorder"})
         self.assertEqual(info["phenotype_disease_source"], {"RCV004545615"})
 
     def test_placeholder_dash_values_are_excluded(self):
-        """Most rows are '-' for these fields; they must not pollute the aggregate."""
-        _, coord_info = up.build_variation_index(self._factory(), {"rs143842750"})
-        info = coord_info["NC_000017.11:g.30178149A>G"]
+        coordinate_info = up.build_variation_aggregate(self.rows)
+        info = coordinate_info["NC_000017.11:g.30178149A>G"]
         self.assertNotIn("-", info["clinical_significance"])
         self.assertNotIn("-", info["phenotype_disease"])
         self.assertNotIn("-", info["phenotype_disease_source"])
 
-    def test_unrelated_coordinate_not_collected(self):
-        _, coord_info = up.build_variation_index(self._factory(), {"rs143842750"})
-        self.assertNotIn("NC_000001.11:g.111A>G", coord_info)
+    def test_unrelated_coordinate_has_its_own_isolated_entry(self):
+        coordinate_info = up.build_variation_aggregate(self.rows)
+        info = coordinate_info["NC_000001.11:g.111A>G"]
+        self.assertEqual(info["source_db_id"], {"rs000000001"})
+        self.assertEqual(info["clinical_significance"], set())
+
+
+# ---------------------------------------------------------------------------
+# build_humsavar_index
+# ---------------------------------------------------------------------------
+
+class TestBuildHumsavarIndex(unittest.TestCase):
+
+    def test_indexes_by_dbsnp_id(self):
+        rows = [{"swiss_prot_ac": "P04217", "ftid": "VAR_018369", "type_of_variant": "LB/B",
+                 "dbsnp_id": "rs893184", "disease_name": None}]
+        index = up.build_humsavar_index(rows)
+        self.assertIn("rs893184", index)
+        self.assertEqual(index["rs893184"][0]["ftid"], "VAR_018369")
+
+    def test_rows_without_dbsnp_id_are_excluded(self):
+        rows = [{"swiss_prot_ac": "P00000", "ftid": "VAR_000001", "type_of_variant": "US",
+                 "dbsnp_id": None, "disease_name": None}]
+        index = up.build_humsavar_index(rows)
+        self.assertEqual(index, {})
+
+    def test_duplicate_dbsnp_id_across_records_both_kept(self):
+        """Real production case: ABCA1's VAR_009147 and VAR_062487 both cite rs137854496."""
+        rows = [
+            {"swiss_prot_ac": "O95477", "ftid": "VAR_009147", "type_of_variant": "LP/P",
+             "dbsnp_id": "rs137854496", "disease_name": "Tangier disease (TGD) [MIM:205400]"},
+            {"swiss_prot_ac": "O95477", "ftid": "VAR_062487", "type_of_variant": "LP/P",
+             "dbsnp_id": "rs137854496", "disease_name": "Tangier disease (TGD) [MIM:205400]"},
+        ]
+        index = up.build_humsavar_index(rows)
+        self.assertEqual(len(index["rs137854496"]), 2)
+        self.assertEqual({r["ftid"] for r in index["rs137854496"]}, {"VAR_009147", "VAR_062487"})
+
+    def test_disease_name_omitted_when_dash(self):
+        rows = [{"swiss_prot_ac": "P00000", "ftid": "VAR_000001", "type_of_variant": "US",
+                 "dbsnp_id": "rs1", "disease_name": None}]
+        index = up.build_humsavar_index(rows)
+        self.assertNotIn("disease_name", index["rs1"][0])
 
 
 # ---------------------------------------------------------------------------
@@ -271,77 +303,78 @@ class TestBuildVariationIndex(unittest.TestCase):
 
 class TestBuildDocs(unittest.TestCase):
 
-    def test_row_without_dbsnp_id_is_skipped(self):
-        humsavar_rows = [{
-            "swiss_prot_ac": "P00000", "ftid": "VAR_000001", "type_of_variant": "US",
-            "dbsnp_id": None, "disease_name": None,
-        }]
-        docs = list(up.build_docs(humsavar_rows, {}, {}))
-        self.assertEqual(docs, [])
+    def test_coordinate_with_no_humsavar_match_has_no_humsavar_field(self):
+        """The common case now: most of the ~15M coordinates have no curated
+        humsavar record at all."""
+        coordinate_info = {
+            "NC_000001.11:g.111A>G": {
+                "source_db_id": {"rs000000001"}, "clinical_significance": set(),
+                "phenotype_disease": set(), "phenotype_disease_source": set(),
+            }
+        }
+        doc = next(iter(up.build_docs(coordinate_info, humsavar_index={})))
+        self.assertEqual(doc["_id"], "chr1:g.111A>G")
+        self.assertNotIn("humsavar", doc["uniprot"])
+        self.assertEqual(doc["uniprot"]["source_db_id"], "rs000000001")
 
-    def test_unresolved_dbsnp_id_is_skipped(self):
-        humsavar_rows = [{
-            "swiss_prot_ac": "P00000", "ftid": "VAR_000001", "type_of_variant": "US",
-            "dbsnp_id": "rs_unresolved", "disease_name": None,
-        }]
-        docs = list(up.build_docs(humsavar_rows, {}, {}))
-        self.assertEqual(docs, [])
-
-    def test_resolved_row_produces_expected_doc(self):
-        humsavar_rows = [{
-            "swiss_prot_ac": "P04217", "ftid": "VAR_018369", "type_of_variant": "LB/B",
-            "dbsnp_id": "rs893184", "disease_name": None,
-        }]
-        dbsnp_to_coord = {"rs893184": "NC_000019.10:g.58864491G>A"}
-        coord_info = {"NC_000019.10:g.58864491G>A": {
-            "source_db_id": {"rs893184"},
-            "clinical_significance": set(),
-            "phenotype_disease": set(),
-            "phenotype_disease_source": set(),
-        }}
-        docs = list(up.build_docs(humsavar_rows, dbsnp_to_coord, coord_info))
-        self.assertEqual(len(docs), 1)
-        doc = docs[0]
-        self.assertEqual(doc["_id"], "chr19:g.58864491G>A")
+    def test_humsavar_attached_when_dbsnp_id_matches(self):
+        coordinate_info = {
+            "NC_000019.10:g.58864491G>A": {
+                "source_db_id": {"rs893184"}, "clinical_significance": set(),
+                "phenotype_disease": set(), "phenotype_disease_source": set(),
+            }
+        }
+        humsavar_index = {"rs893184": [{"swiss_prot_ac": "P04217", "ftid": "VAR_018369",
+                                         "type_of_variant": "LB/B"}]}
+        doc = next(iter(up.build_docs(coordinate_info, humsavar_index)))
         self.assertEqual(doc["uniprot"]["humsavar"], {
             "swiss_prot_ac": "P04217", "ftid": "VAR_018369", "type_of_variant": "LB/B",
         })
-        # single value -> unlist() collapses it to a scalar, matching prod's shape
-        self.assertEqual(doc["uniprot"]["source_db_id"], "rs893184")
 
-    def test_multi_valued_source_db_id_stays_a_sorted_list(self):
-        """Mirrors the real NSRP1 p.Lys30Glu case: rs + 2 RCV ids at one position."""
-        humsavar_rows = [{
-            "swiss_prot_ac": "A0A024QZ33", "ftid": "VAR_999999", "type_of_variant": "LB/B",
-            "dbsnp_id": "rs143842750", "disease_name": None,
-        }]
-        dbsnp_to_coord = {"rs143842750": "NC_000017.11:g.30178149A>G"}
-        coord_info = {"NC_000017.11:g.30178149A>G": {
-            "source_db_id": {"rs143842750", "RCV004292335", "RCV004545615"},
-            "clinical_significance": {"Likely benign"},
-            "phenotype_disease": {"NSRP1-related disorder"},
-            "phenotype_disease_source": {"RCV004545615"},
-        }}
-        doc = next(iter(up.build_docs(humsavar_rows, dbsnp_to_coord, coord_info)))
-        self.assertEqual(doc["_id"], "chr17:g.30178149A>G")
+    def test_unrecognized_coordinate_is_skipped(self):
+        coordinate_info = {
+            "NC_999999.1:g.1A>G": {
+                "source_db_id": {"rsXXX"}, "clinical_significance": set(),
+                "phenotype_disease": set(), "phenotype_disease_source": set(),
+            }
+        }
+        docs = list(up.build_docs(coordinate_info, humsavar_index={}))
+        self.assertEqual(docs, [])
+
+    def test_multiple_humsavar_matches_become_a_list(self):
+        """Real production case: ABCA1's two FTIds both cite rs137854496, which is
+        also one of this coordinate's source_db_id values."""
+        coordinate_info = {
+            "NC_000009.12:g.104831048C>G": {
+                "source_db_id": {"rs137854496", "RCV000010098", "RCV001509362"},
+                "clinical_significance": {"Pathogenic"},
+                "phenotype_disease": set(), "phenotype_disease_source": set(),
+            }
+        }
+        humsavar_index = {
+            "rs137854496": [
+                {"swiss_prot_ac": "O95477", "ftid": "VAR_009147", "type_of_variant": "LP/P"},
+                {"swiss_prot_ac": "O95477", "ftid": "VAR_062487", "type_of_variant": "LP/P"},
+            ]
+        }
+        doc = next(iter(up.build_docs(coordinate_info, humsavar_index)))
+        humsavar = doc["uniprot"]["humsavar"]
+        self.assertIsInstance(humsavar, list)
+        self.assertEqual({h["ftid"] for h in humsavar}, {"VAR_009147", "VAR_062487"})
         self.assertEqual(sorted(doc["uniprot"]["source_db_id"]),
-                          ["RCV004292335", "RCV004545615", "rs143842750"])
-        self.assertEqual(doc["uniprot"]["clinical_significance"], "Likely benign")
+                          ["RCV000010098", "RCV001509362", "rs137854496"])
 
     def test_no_extra_fields_beyond_existing_mapping(self):
-        """Decision 3: no Evidence/Consequence Type/etc. fields are ever added."""
-        humsavar_rows = [{
-            "swiss_prot_ac": "P04217", "ftid": "VAR_018369", "type_of_variant": "LB/B",
-            "dbsnp_id": "rs893184", "disease_name": "Some disease",
-        }]
-        dbsnp_to_coord = {"rs893184": "NC_000019.10:g.58864491G>A"}
-        coord_info = {"NC_000019.10:g.58864491G>A": {
-            "source_db_id": {"rs893184"},
-            "clinical_significance": {"Pathogenic"},
-            "phenotype_disease": {"Some phenotype"},
-            "phenotype_disease_source": {"MIM:12345"},
-        }}
-        doc = next(iter(up.build_docs(humsavar_rows, dbsnp_to_coord, coord_info)))
+        """Standing decision: no Evidence/Consequence Type/etc. fields are ever added."""
+        coordinate_info = {
+            "NC_000019.10:g.58864491G>A": {
+                "source_db_id": {"rs893184"}, "clinical_significance": {"Pathogenic"},
+                "phenotype_disease": {"Some phenotype"}, "phenotype_disease_source": {"MIM:12345"},
+            }
+        }
+        humsavar_index = {"rs893184": [{"swiss_prot_ac": "P04217", "ftid": "VAR_018369",
+                                         "type_of_variant": "LB/B", "disease_name": "Some disease"}]}
+        doc = next(iter(up.build_docs(coordinate_info, humsavar_index)))
         self.assertEqual(set(doc["uniprot"].keys()), {
             "humsavar", "source_db_id", "clinical_significance",
             "phenotype_disease", "phenotype_disease_source",
@@ -356,72 +389,50 @@ class TestBuildDocs(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 class TestMergeDocs(unittest.TestCase):
-    """
-    Regression test for a real production crash: two distinct humsavar.txt
-    records for ABCA1 (VAR_009147 p.Trp590Ser and VAR_062487 p.Trp590Leu) both
-    reference the same dbSNP id, rs137854496 -- a UniProt curation duplicate
-    that was never cleaned up. Both resolve to the same genomic coordinate
-    (chr9:g.104831048C>G), so build_docs() yields two documents with the same
-    _id. Storage does a plain insert (not upsert), so without merging this
-    crashes the whole batch with a MongoDB E11000 duplicate key error.
-    """
-
-    def setUp(self):
-        self.doc_a = {
-            "_id": "chr9:g.104831048C>G",
-            "uniprot": {
-                "humsavar": {"swiss_prot_ac": "O95477", "ftid": "VAR_009147",
-                             "type_of_variant": "LP/P",
-                             "disease_name": "Tangier disease (TGD) [MIM:205400]"},
-                "source_db_id": "rs137854496",
-            },
-        }
-        self.doc_b = {
-            "_id": "chr9:g.104831048C>G",
-            "uniprot": {
-                "humsavar": {"swiss_prot_ac": "O95477", "ftid": "VAR_062487",
-                             "type_of_variant": "LP/P",
-                             "disease_name": "Tangier disease (TGD) [MIM:205400]"},
-                "source_db_id": ["RCV000010098", "RCV001509362", "rs137854496"],
-                "clinical_significance": "Variant of uncertain significance, Likely pathogenic, Pathogenic",
-                "phenotype_disease": ["Tangier disease (TGD)", "Tangier disease (tgd)"],
-                "phenotype_disease_source": "MIM:205400, 31751110, RCV000010098",
-            },
-        }
 
     def test_non_colliding_docs_pass_through_unchanged(self):
-        other = {"_id": "chr1:g.1A>G", "uniprot": {"humsavar": {"ftid": "VAR_1"}}}
-        docs = list(up.merge_docs([self.doc_a, other]))
+        doc_a = {"_id": "chr1:g.1A>G", "uniprot": {"source_db_id": "rs1"}}
+        doc_b = {"_id": "chr2:g.2A>G", "uniprot": {"source_db_id": "rs2"}}
+        docs = list(up.merge_docs([doc_a, doc_b]))
         self.assertEqual(len(docs), 2)
-        self.assertIn(other, docs)
+        self.assertIn(doc_a, docs)
+        self.assertIn(doc_b, docs)
 
-    def test_colliding_docs_produce_a_single_document(self):
-        docs = list(up.merge_docs([self.doc_a, self.doc_b]))
+    def test_colliding_docs_merge_into_one_and_union_source_db_id(self):
+        doc_a = {"_id": "chr9:g.104831048C>G", "uniprot": {"source_db_id": "rs137854496"}}
+        doc_b = {"_id": "chr9:g.104831048C>G", "uniprot": {"source_db_id": ["RCV000010098", "rs137854496"]}}
+        docs = list(up.merge_docs([doc_a, doc_b]))
         self.assertEqual(len(docs), 1, "must not crash storage with two docs sharing an _id")
-        self.assertEqual(docs[0]["_id"], "chr9:g.104831048C>G")
+        self.assertEqual(sorted(docs[0]["uniprot"]["source_db_id"]),
+                          ["RCV000010098", "rs137854496"])
 
-    def test_humsavar_becomes_a_list_of_both_records(self):
-        merged = next(iter(up.merge_docs([self.doc_a, self.doc_b])))
+    def test_colliding_docs_union_humsavar_records(self):
+        doc_a = {"_id": "chr9:g.104831048C>G",
+                 "uniprot": {"humsavar": {"ftid": "VAR_009147", "swiss_prot_ac": "O95477",
+                                           "type_of_variant": "LP/P"}}}
+        doc_b = {"_id": "chr9:g.104831048C>G",
+                 "uniprot": {"humsavar": {"ftid": "VAR_062487", "swiss_prot_ac": "O95477",
+                                           "type_of_variant": "LP/P"}}}
+        merged = next(iter(up.merge_docs([doc_a, doc_b])))
         humsavar = merged["uniprot"]["humsavar"]
         self.assertIsInstance(humsavar, list)
         self.assertEqual({h["ftid"] for h in humsavar}, {"VAR_009147", "VAR_062487"})
 
-    def test_source_db_id_unioned_across_scalar_and_list_values(self):
-        """doc_a has a scalar source_db_id, doc_b has a list -- both must merge cleanly."""
-        merged = next(iter(up.merge_docs([self.doc_a, self.doc_b])))
-        self.assertEqual(sorted(merged["uniprot"]["source_db_id"]),
-                          ["RCV000010098", "RCV001509362", "rs137854496"])
+    def test_one_doc_with_humsavar_one_without_still_merges(self):
+        doc_a = {"_id": "chr1:g.1A>G", "uniprot": {"source_db_id": "rs1"}}
+        doc_b = {"_id": "chr1:g.1A>G",
+                 "uniprot": {"source_db_id": "rs2",
+                             "humsavar": {"ftid": "VAR_1", "swiss_prot_ac": "P1", "type_of_variant": "US"}}}
+        merged = next(iter(up.merge_docs([doc_a, doc_b])))
+        self.assertEqual(merged["uniprot"]["humsavar"], {
+            "ftid": "VAR_1", "swiss_prot_ac": "P1", "type_of_variant": "US",
+        })
+        self.assertEqual(sorted(merged["uniprot"]["source_db_id"]), ["rs1", "rs2"])
 
-    def test_enrichment_fields_from_either_doc_are_preserved(self):
-        merged = next(iter(up.merge_docs([self.doc_a, self.doc_b])))
-        self.assertEqual(merged["uniprot"]["clinical_significance"],
-                          "Variant of uncertain significance, Likely pathogenic, Pathogenic")
-        self.assertEqual(sorted(merged["uniprot"]["phenotype_disease"]),
-                          ["Tangier disease (TGD)", "Tangier disease (tgd)"])
-
-    def test_single_doc_group_is_not_wrapped_in_extra_list(self):
-        """The overwhelmingly common case (no collision) must keep humsavar as a plain dict."""
-        docs = list(up.merge_docs([self.doc_a]))
+    def test_single_doc_group_keeps_humsavar_as_a_plain_dict(self):
+        doc_a = {"_id": "chr1:g.1A>G",
+                 "uniprot": {"humsavar": {"ftid": "VAR_1", "swiss_prot_ac": "P1", "type_of_variant": "US"}}}
+        docs = list(up.merge_docs([doc_a]))
         self.assertEqual(len(docs), 1)
         self.assertIsInstance(docs[0]["uniprot"]["humsavar"], dict)
 
@@ -440,12 +451,10 @@ class TestLoadDataIntegration(unittest.TestCase):
 
         with open(os.path.join(self.tmpdir, up.HUMSAVAR_FILE), "w") as f:
             f.writelines(_HUMSAVAR_PREAMBLE)
-            # resolvable row (matches a variation-file row below)
+            # matches a variation-file row below -> gets a humsavar field
             f.write("A1BG        P04217     VAR_018369  p.His52Arg     LB/B     rs893184       -\n")
-            # unresolvable row: no matching entry in the variation file
-            f.write("A1BG        P04217     VAR_018370  p.His395Arg    LB/B     rs2241788      -\n")
-            # unresolvable row: no dbSNP id at all
-            f.write("AARS1       P49588     VAR_073293  p.Thr608Met    US       -              -\n")
+            # dbSNP id not present anywhere in the variation file -> no effect on output
+            f.write("A1BG        P04217     VAR_018370  p.His395Arg    LB/B     rs_not_in_variation_file      -\n")
             # regression case: two distinct humsavar records sharing one dbSNP id
             # (real production case: ABCA1 VAR_009147/VAR_062487 both rs137854496)
             f.write("ABCA1       O95477     VAR_009147  p.Trp590Ser    LP/P     rs137854496    "
@@ -456,11 +465,15 @@ class TestLoadDataIntegration(unittest.TestCase):
         variation_path = os.path.join(self.tmpdir, "homo_sapiens_variation.txt.gz")
         with gzip.open(variation_path, "wt") as f:
             f.writelines(_VARIATION_PREAMBLE)
+            # this coordinate matches humsavar's rs893184
             f.write(_variation_row("rs893184", "NC_000019.10:g.58864491G>A",
                                     gene="A1BG", aa="p.His52Arg"))
-            # a second source at that same position, to exercise aggregation end-to-end
             f.write(_variation_row("RCV000012345", "NC_000019.10:g.58864491G>A",
                                     clinsig="Benign", gene="A1BG", aa="p.His52Arg"))
+            # this coordinate has NO humsavar match at all -- the new common case
+            f.write(_variation_row("rs999999999", "NC_000002.12:g.500A>T",
+                                    gene="OTHERGENE", ac="Q00000", aa="p.Ala1Val"))
+            # matches humsavar's duplicate-dbSNP-id case
             f.write(_variation_row("rs137854496", "NC_000009.12:g.104831048C>G",
                                     clinsig="Pathogenic", gene="ABCA1", ac="O95477", aa="p.Trp590Ser"))
 
@@ -468,35 +481,45 @@ class TestLoadDataIntegration(unittest.TestCase):
         import shutil
         shutil.rmtree(self.tmpdir, ignore_errors=True)
 
-    def test_end_to_end(self):
+    def test_every_variation_coordinate_produces_a_document(self):
+        """The base file drives output now: all 3 coordinates in the fixture
+        appear, regardless of whether humsavar has anything for them."""
         docs = up.load_data(self.tmpdir)
-        # 2 resolvable groups: the A1BG row, and the merged ABCA1 pair (the 2
-        # unresolvable/no-dbSNP-id rows are skipped, not 4 separate documents)
-        self.assertEqual(len(docs), 2)
-        by_id = {d["_id"]: d for d in docs}
+        self.assertEqual({d["_id"] for d in docs}, {
+            "chr19:g.58864491G>A", "chr2:g.500A>T", "chr9:g.104831048C>G",
+        })
 
+    def test_coordinate_with_humsavar_match_is_enriched(self):
+        docs = up.load_data(self.tmpdir)
+        by_id = {d["_id"]: d for d in docs}
         doc = by_id["chr19:g.58864491G>A"]
         self.assertEqual(sorted(doc["uniprot"]["source_db_id"]),
                           ["RCV000012345", "rs893184"])
         self.assertEqual(doc["uniprot"]["clinical_significance"], "Benign")
         self.assertEqual(doc["uniprot"]["humsavar"]["swiss_prot_ac"], "P04217")
 
-    def test_end_to_end_merges_duplicate_dbsnp_id_across_humsavar_records(self):
+    def test_coordinate_without_humsavar_match_has_no_humsavar_field(self):
+        docs = up.load_data(self.tmpdir)
+        by_id = {d["_id"]: d for d in docs}
+        doc = by_id["chr2:g.500A>T"]
+        self.assertNotIn("humsavar", doc["uniprot"])
+        self.assertEqual(doc["uniprot"]["source_db_id"], "rs999999999")
+
+    def test_duplicate_dbsnp_id_across_humsavar_records_is_merged_not_crashed(self):
         """
-        Regression test for the production crash: without merge_docs(), this
-        scenario yields two raw documents with _id 'chr9:g.104831048C>G' and
-        crashes storage.process()'s plain insert_many() with E11000. Here it
-        must produce exactly one merged document instead.
+        Regression test for the production crash this was originally built to
+        fix: without the merge, two raw humsavar-derived records at the same
+        coordinate would either duplicate the _id (old design) or, in the new
+        design, both attach to the single coordinate doc and must be combined
+        into one 'humsavar' list rather than raising or overwriting silently.
         """
         docs = up.load_data(self.tmpdir)
         by_id = {d["_id"]: d for d in docs}
-        self.assertIn("chr9:g.104831048C>G", by_id)
-        merged = by_id["chr9:g.104831048C>G"]
-        humsavar = merged["uniprot"]["humsavar"]
+        doc = by_id["chr9:g.104831048C>G"]
+        humsavar = doc["uniprot"]["humsavar"]
         self.assertIsInstance(humsavar, list)
         self.assertEqual({h["ftid"] for h in humsavar}, {"VAR_009147", "VAR_062487"})
-        self.assertEqual(merged["uniprot"]["source_db_id"], "rs137854496")
-        self.assertEqual(merged["uniprot"]["clinical_significance"], "Pathogenic")
+        self.assertEqual(doc["uniprot"]["clinical_significance"], "Pathogenic")
 
     def test_missing_variation_file_raises(self):
         import tempfile

--- a/src/tests/data/test_uniprot_parser.py
+++ b/src/tests/data/test_uniprot_parser.py
@@ -1,15 +1,20 @@
 """
 Unit tests for the 'uniprot' myvariant.info source parser.
 
-Architecture (per direct decision from the source owner, overriding an
-earlier humsavar-driven design): homo_sapiens_variation.txt.gz is the base --
-every unique genomic coordinate found there becomes one output document,
-enriched with whatever source_db_id/clinical_significance/phenotype_disease/
-phenotype_disease_source values UniProt reports at that position. humsavar.txt
-(~85K manually curated records, vs. ~15M coordinates in the base file) is
-attached on top, only when available: a document gets a 'humsavar' field only
-if one of its source_db_id values matches a dbSNP id humsavar.txt references.
-Most documents won't have one.
+Architecture (per direct decision from the source owner): load ALL data from
+both humsavar.txt and homo_sapiens_variation.txt.gz, connecting records that
+relate to each other:
+
+  - Every unique genomic coordinate in homo_sapiens_variation.txt.gz becomes
+    a document, enriched with whatever source_db_id/clinical_significance/
+    phenotype_disease/phenotype_disease_source values UniProt reports there.
+  - Every humsavar.txt record whose dbSNP id matches one of a coordinate's
+    source_db_id values gets attached to that coordinate's document -- these
+    are the documents with data from both files.
+  - Every humsavar.txt record that never matches anything (no dbSNP id, or
+    a dbSNP id absent from the variation file -- about 17% of humsavar.txt)
+    still becomes its own standalone document, with a random _id (no
+    genomic coordinate to derive a real one from) rather than being dropped.
 
 Other standing decisions this parser implements:
   - humsavar.txt's variant-category vocabulary (now ACMG/AMP-style: LP/P,
@@ -50,11 +55,6 @@ class TestNcCoordinateToHgvsId(unittest.TestCase):
             up.nc_coordinate_to_hgvs_id("NC_000017.11:g.30178149A>G"),
             "chr17:g.30178149A>G")
 
-    def test_chr1(self):
-        self.assertEqual(
-            up.nc_coordinate_to_hgvs_id("NC_000001.11:g.12345C>T"),
-            "chr1:g.12345C>T")
-
     def test_chrX(self):
         self.assertEqual(
             up.nc_coordinate_to_hgvs_id("NC_000023.11:g.99A>T"),
@@ -71,8 +71,6 @@ class TestNcCoordinateToHgvsId(unittest.TestCase):
             "chrMT:g.1234A>G")
 
     def test_assembly_patch_version_is_ignored(self):
-        """Only the accession prefix (before the dot) determines the chromosome,
-        so this is robust to GRCh38 patch version bumps."""
         self.assertEqual(
             up.nc_coordinate_to_hgvs_id("NC_000017.12:g.1A>G"),
             "chr17:g.1A>G")
@@ -85,7 +83,7 @@ class TestNcCoordinateToHgvsId(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# parse_humsavar
+# parse_humsavar / parse_variation
 # ---------------------------------------------------------------------------
 
 _HUMSAVAR_PREAMBLE = [
@@ -95,60 +93,6 @@ _HUMSAVAR_PREAMBLE = [
     "gene name   AC         FTId        change         category dbSNP          Disease name\n",
     "_________   __________ ___________ ______________ ________ ______________ _____________________\n",
 ]
-
-
-class TestParseHumsavar(unittest.TestCase):
-
-    def test_skips_preamble(self):
-        rows = list(up.parse_humsavar(_HUMSAVAR_PREAMBLE))
-        self.assertEqual(rows, [])
-
-    def test_parses_basic_row(self):
-        lines = _HUMSAVAR_PREAMBLE + [
-            "A1BG        P04217     VAR_018369  p.His52Arg     LB/B     rs893184       -\n",
-        ]
-        rows = list(up.parse_humsavar(lines))
-        self.assertEqual(len(rows), 1)
-        row = rows[0]
-        self.assertEqual(row["swiss_prot_ac"], "P04217")
-        self.assertEqual(row["ftid"], "VAR_018369")
-        self.assertEqual(row["type_of_variant"], "LB/B")
-        self.assertEqual(row["dbsnp_id"], "rs893184")
-        self.assertIsNone(row["disease_name"])
-
-    def test_new_acmg_vocabulary_kept_as_is(self):
-        """Standing decision: the current LP/P/LB/B/US vocabulary is not translated."""
-        lines = _HUMSAVAR_PREAMBLE + [
-            "AAAS        Q9NRG9     VAR_012804  p.Gln15Lys     LP/P     rs121918549    "
-            "Achalasia-addisonianism-alacrima syndrome (AAAS) [MIM:231550]\n",
-        ]
-        row = next(iter(up.parse_humsavar(lines)))
-        self.assertEqual(row["type_of_variant"], "LP/P")
-        self.assertEqual(
-            row["disease_name"],
-            "Achalasia-addisonianism-alacrima syndrome (AAAS) [MIM:231550]")
-
-    def test_missing_dbsnp_id_is_none(self):
-        lines = _HUMSAVAR_PREAMBLE + [
-            "AARS1       P49588     VAR_073293  p.Thr608Met    US       -              -\n",
-        ]
-        row = next(iter(up.parse_humsavar(lines)))
-        self.assertIsNone(row["dbsnp_id"])
-        self.assertIsNone(row["disease_name"])
-
-    def test_blank_lines_are_skipped(self):
-        lines = _HUMSAVAR_PREAMBLE + [
-            "\n",
-            "A1BG        P04217     VAR_018369  p.His52Arg     LB/B     rs893184       -\n",
-            "\n",
-        ]
-        rows = list(up.parse_humsavar(lines))
-        self.assertEqual(len(rows), 1)
-
-
-# ---------------------------------------------------------------------------
-# parse_variation
-# ---------------------------------------------------------------------------
 
 _VARIATION_PREAMBLE = [
     "Description:     Index of Protein Altering Variants (SO:0001818)\n",
@@ -176,25 +120,55 @@ def _variation_row(source_db_id, coordinate, clinsig="-", pheno="-", pheno_src="
     ]) + "\n"
 
 
+class TestParseHumsavar(unittest.TestCase):
+
+    def test_skips_preamble(self):
+        self.assertEqual(list(up.parse_humsavar(_HUMSAVAR_PREAMBLE)), [])
+
+    def test_parses_basic_row(self):
+        lines = _HUMSAVAR_PREAMBLE + [
+            "A1BG        P04217     VAR_018369  p.His52Arg     LB/B     rs893184       -\n",
+        ]
+        row = next(iter(up.parse_humsavar(lines)))
+        self.assertEqual(row["swiss_prot_ac"], "P04217")
+        self.assertEqual(row["ftid"], "VAR_018369")
+        self.assertEqual(row["type_of_variant"], "LB/B")
+        self.assertEqual(row["dbsnp_id"], "rs893184")
+        self.assertIsNone(row["disease_name"])
+
+    def test_new_acmg_vocabulary_kept_as_is(self):
+        lines = _HUMSAVAR_PREAMBLE + [
+            "AAAS        Q9NRG9     VAR_012804  p.Gln15Lys     LP/P     rs121918549    "
+            "Achalasia-addisonianism-alacrima syndrome (AAAS) [MIM:231550]\n",
+        ]
+        row = next(iter(up.parse_humsavar(lines)))
+        self.assertEqual(row["type_of_variant"], "LP/P")
+        self.assertEqual(
+            row["disease_name"],
+            "Achalasia-addisonianism-alacrima syndrome (AAAS) [MIM:231550]")
+
+    def test_missing_dbsnp_id_is_none(self):
+        lines = _HUMSAVAR_PREAMBLE + [
+            "AARS1       P49588     VAR_073293  p.Thr608Met    US       -              -\n",
+        ]
+        row = next(iter(up.parse_humsavar(lines)))
+        self.assertIsNone(row["dbsnp_id"])
+
+
 class TestParseVariation(unittest.TestCase):
 
     def test_skips_preamble(self):
-        rows = list(up.parse_variation(_VARIATION_PREAMBLE))
-        self.assertEqual(rows, [])
+        self.assertEqual(list(up.parse_variation(_VARIATION_PREAMBLE)), [])
 
     def test_parses_basic_row(self):
-        lines = _VARIATION_PREAMBLE + [
-            _variation_row("rs965203080", "NC_000017.11:g.30172593A>G"),
-        ]
-        rows = list(up.parse_variation(lines))
-        self.assertEqual(len(rows), 1)
-        self.assertEqual(rows[0]["source_db_id"], "rs965203080")
-        self.assertEqual(rows[0]["coordinate"], "NC_000017.11:g.30172593A>G")
+        lines = _VARIATION_PREAMBLE + [_variation_row("rs965203080", "NC_000017.11:g.30172593A>G")]
+        row = next(iter(up.parse_variation(lines)))
+        self.assertEqual(row["source_db_id"], "rs965203080")
+        self.assertEqual(row["coordinate"], "NC_000017.11:g.30172593A>G")
 
     def test_short_malformed_row_is_skipped(self):
         lines = _VARIATION_PREAMBLE + ["too\tshort\n"]
-        rows = list(up.parse_variation(lines))
-        self.assertEqual(rows, [])
+        self.assertEqual(list(up.parse_variation(lines)), [])
 
 
 # ---------------------------------------------------------------------------
@@ -218,15 +192,11 @@ class TestBuildVariationAggregate(unittest.TestCase):
             {"source_db_id": "RCV004545615", "coordinate": "NC_000017.11:g.30178149A>G",
              "clinical_significance": "Likely benign", "phenotype_disease": "NSRP1-related disorder",
              "phenotype_disease_source": "RCV004545615"},
-            # a wholly unrelated coordinate, to prove aggregation doesn't cross-contaminate
-            "SENTINEL",
+            {"source_db_id": "rs000000001", "coordinate": "NC_000001.11:g.111A>G",
+             "clinical_significance": "-", "phenotype_disease": "-", "phenotype_disease_source": "-"},
         ]
-        self.rows[-1] = {"source_db_id": "rs000000001", "coordinate": "NC_000001.11:g.111A>G",
-                          "clinical_significance": "-", "phenotype_disease": "-", "phenotype_disease_source": "-"}
 
     def test_every_coordinate_becomes_a_key(self):
-        """Unlike the old humsavar-driven design, ALL coordinates are aggregated,
-        not just a pre-selected subset -- this is the base file now."""
         coordinate_info = up.build_variation_aggregate(self.rows)
         self.assertEqual(set(coordinate_info.keys()), {
             "NC_000017.11:g.30178149A>G", "NC_000001.11:g.111A>G",
@@ -235,66 +205,12 @@ class TestBuildVariationAggregate(unittest.TestCase):
     def test_aggregates_all_source_db_ids_sharing_a_coordinate(self):
         coordinate_info = up.build_variation_aggregate(self.rows)
         info = coordinate_info["NC_000017.11:g.30178149A>G"]
-        self.assertEqual(info["source_db_id"],
-                          {"rs143842750", "RCV004292335", "RCV004545615"})
-
-    def test_aggregates_clinical_and_phenotype_fields(self):
-        coordinate_info = up.build_variation_aggregate(self.rows)
-        info = coordinate_info["NC_000017.11:g.30178149A>G"]
-        self.assertEqual(info["clinical_significance"], {"Likely benign"})
-        self.assertEqual(info["phenotype_disease"], {"NSRP1-related disorder"})
-        self.assertEqual(info["phenotype_disease_source"], {"RCV004545615"})
+        self.assertEqual(info["source_db_id"], {"rs143842750", "RCV004292335", "RCV004545615"})
 
     def test_placeholder_dash_values_are_excluded(self):
         coordinate_info = up.build_variation_aggregate(self.rows)
         info = coordinate_info["NC_000017.11:g.30178149A>G"]
         self.assertNotIn("-", info["clinical_significance"])
-        self.assertNotIn("-", info["phenotype_disease"])
-        self.assertNotIn("-", info["phenotype_disease_source"])
-
-    def test_unrelated_coordinate_has_its_own_isolated_entry(self):
-        coordinate_info = up.build_variation_aggregate(self.rows)
-        info = coordinate_info["NC_000001.11:g.111A>G"]
-        self.assertEqual(info["source_db_id"], {"rs000000001"})
-        self.assertEqual(info["clinical_significance"], set())
-
-
-# ---------------------------------------------------------------------------
-# build_humsavar_index
-# ---------------------------------------------------------------------------
-
-class TestBuildHumsavarIndex(unittest.TestCase):
-
-    def test_indexes_by_dbsnp_id(self):
-        rows = [{"swiss_prot_ac": "P04217", "ftid": "VAR_018369", "type_of_variant": "LB/B",
-                 "dbsnp_id": "rs893184", "disease_name": None}]
-        index = up.build_humsavar_index(rows)
-        self.assertIn("rs893184", index)
-        self.assertEqual(index["rs893184"][0]["ftid"], "VAR_018369")
-
-    def test_rows_without_dbsnp_id_are_excluded(self):
-        rows = [{"swiss_prot_ac": "P00000", "ftid": "VAR_000001", "type_of_variant": "US",
-                 "dbsnp_id": None, "disease_name": None}]
-        index = up.build_humsavar_index(rows)
-        self.assertEqual(index, {})
-
-    def test_duplicate_dbsnp_id_across_records_both_kept(self):
-        """Real production case: ABCA1's VAR_009147 and VAR_062487 both cite rs137854496."""
-        rows = [
-            {"swiss_prot_ac": "O95477", "ftid": "VAR_009147", "type_of_variant": "LP/P",
-             "dbsnp_id": "rs137854496", "disease_name": "Tangier disease (TGD) [MIM:205400]"},
-            {"swiss_prot_ac": "O95477", "ftid": "VAR_062487", "type_of_variant": "LP/P",
-             "dbsnp_id": "rs137854496", "disease_name": "Tangier disease (TGD) [MIM:205400]"},
-        ]
-        index = up.build_humsavar_index(rows)
-        self.assertEqual(len(index["rs137854496"]), 2)
-        self.assertEqual({r["ftid"] for r in index["rs137854496"]}, {"VAR_009147", "VAR_062487"})
-
-    def test_disease_name_omitted_when_dash(self):
-        rows = [{"swiss_prot_ac": "P00000", "ftid": "VAR_000001", "type_of_variant": "US",
-                 "dbsnp_id": "rs1", "disease_name": None}]
-        index = up.build_humsavar_index(rows)
-        self.assertNotIn("disease_name", index["rs1"][0])
 
 
 # ---------------------------------------------------------------------------
@@ -304,83 +220,108 @@ class TestBuildHumsavarIndex(unittest.TestCase):
 class TestBuildDocs(unittest.TestCase):
 
     def test_coordinate_with_no_humsavar_match_has_no_humsavar_field(self):
-        """The common case now: most of the ~15M coordinates have no curated
-        humsavar record at all."""
         coordinate_info = {
             "NC_000001.11:g.111A>G": {
                 "source_db_id": {"rs000000001"}, "clinical_significance": set(),
                 "phenotype_disease": set(), "phenotype_disease_source": set(),
             }
         }
-        doc = next(iter(up.build_docs(coordinate_info, humsavar_index={})))
-        self.assertEqual(doc["_id"], "chr1:g.111A>G")
-        self.assertNotIn("humsavar", doc["uniprot"])
-        self.assertEqual(doc["uniprot"]["source_db_id"], "rs000000001")
+        docs = list(up.build_docs(coordinate_info, []))
+        self.assertEqual(len(docs), 1)
+        self.assertEqual(docs[0]["_id"], "chr1:g.111A>G")
+        self.assertNotIn("humsavar", docs[0]["uniprot"])
 
     def test_humsavar_attached_when_dbsnp_id_matches(self):
+        """A document with data from both files."""
         coordinate_info = {
             "NC_000019.10:g.58864491G>A": {
                 "source_db_id": {"rs893184"}, "clinical_significance": set(),
                 "phenotype_disease": set(), "phenotype_disease_source": set(),
             }
         }
-        humsavar_index = {"rs893184": [{"swiss_prot_ac": "P04217", "ftid": "VAR_018369",
-                                         "type_of_variant": "LB/B"}]}
-        doc = next(iter(up.build_docs(coordinate_info, humsavar_index)))
-        self.assertEqual(doc["uniprot"]["humsavar"], {
-            "swiss_prot_ac": "P04217", "ftid": "VAR_018369", "type_of_variant": "LB/B",
-        })
+        humsavar_rows = [{"swiss_prot_ac": "P04217", "ftid": "VAR_018369",
+                          "type_of_variant": "LB/B", "dbsnp_id": "rs893184", "disease_name": None}]
+        doc = next(iter(up.build_docs(coordinate_info, humsavar_rows)))
+        self.assertEqual(doc["uniprot"]["humsavar"],
+                          {"swiss_prot_ac": "P04217", "ftid": "VAR_018369", "type_of_variant": "LB/B"})
+        self.assertEqual(doc["uniprot"]["source_db_id"], "rs893184")
 
-    def test_unrecognized_coordinate_is_skipped(self):
+    def test_unmatched_humsavar_row_becomes_standalone_document(self):
+        """Every humsavar record must end up as a document somewhere, even
+        with no dbSNP id at all -- the key new behavior vs. the earlier
+        variation-as-base design, which silently dropped these."""
+        humsavar_rows = [{"swiss_prot_ac": "P49588", "ftid": "VAR_073293",
+                          "type_of_variant": "US", "dbsnp_id": None, "disease_name": None}]
+        docs = list(up.build_docs({}, humsavar_rows))
+        self.assertEqual(len(docs), 1)
+        self.assertIn("_id", docs[0])
+        self.assertTrue(docs[0]["_id"])  # a random id, not a specific known value
+        self.assertEqual(docs[0]["uniprot"], {"humsavar": {
+            "swiss_prot_ac": "P49588", "ftid": "VAR_073293", "type_of_variant": "US",
+        }})
+
+    def test_humsavar_row_with_dbsnp_id_absent_from_variation_file_becomes_standalone(self):
+        """Has a dbSNP id, but it never appears in homo_sapiens_variation.txt.gz."""
         coordinate_info = {
-            "NC_999999.1:g.1A>G": {
-                "source_db_id": {"rsXXX"}, "clinical_significance": set(),
+            "NC_000001.11:g.111A>G": {
+                "source_db_id": {"rs_unrelated"}, "clinical_significance": set(),
                 "phenotype_disease": set(), "phenotype_disease_source": set(),
             }
         }
-        docs = list(up.build_docs(coordinate_info, humsavar_index={}))
-        self.assertEqual(docs, [])
+        humsavar_rows = [{"swiss_prot_ac": "P00000", "ftid": "VAR_000001",
+                          "type_of_variant": "US", "dbsnp_id": "rs_not_in_variation_file", "disease_name": None}]
+        docs = list(up.build_docs(coordinate_info, humsavar_rows))
+        self.assertEqual(len(docs), 2)
+        standalone = [d for d in docs if d["_id"] != "chr1:g.111A>G"][0]
+        self.assertEqual(standalone["uniprot"]["humsavar"]["ftid"], "VAR_000001")
 
-    def test_multiple_humsavar_matches_become_a_list(self):
-        """Real production case: ABCA1's two FTIds both cite rs137854496, which is
-        also one of this coordinate's source_db_id values."""
+    def test_standalone_documents_get_distinct_random_ids(self):
+        humsavar_rows = [
+            {"swiss_prot_ac": "P1", "ftid": "VAR_1", "type_of_variant": "US", "dbsnp_id": None, "disease_name": None},
+            {"swiss_prot_ac": "P2", "ftid": "VAR_2", "type_of_variant": "US", "dbsnp_id": None, "disease_name": None},
+        ]
+        docs = list(up.build_docs({}, humsavar_rows))
+        self.assertEqual(len(docs), 2)
+        ids = {d["_id"] for d in docs}
+        self.assertEqual(len(ids), 2)
+        self.assertTrue(all(isinstance(i, str) and i for i in ids))
+
+    def test_multiple_humsavar_matches_at_one_coordinate_become_a_list(self):
+        """Real production case: ABCA1's two FTIds both cite rs137854496, both
+        of which end up attached (not standalone) since the id matches."""
         coordinate_info = {
             "NC_000009.12:g.104831048C>G": {
-                "source_db_id": {"rs137854496", "RCV000010098", "RCV001509362"},
+                "source_db_id": {"rs137854496", "RCV000010098"},
                 "clinical_significance": {"Pathogenic"},
                 "phenotype_disease": set(), "phenotype_disease_source": set(),
             }
         }
-        humsavar_index = {
-            "rs137854496": [
-                {"swiss_prot_ac": "O95477", "ftid": "VAR_009147", "type_of_variant": "LP/P"},
-                {"swiss_prot_ac": "O95477", "ftid": "VAR_062487", "type_of_variant": "LP/P"},
-            ]
-        }
-        doc = next(iter(up.build_docs(coordinate_info, humsavar_index)))
-        humsavar = doc["uniprot"]["humsavar"]
+        humsavar_rows = [
+            {"swiss_prot_ac": "O95477", "ftid": "VAR_009147", "type_of_variant": "LP/P",
+             "dbsnp_id": "rs137854496", "disease_name": None},
+            {"swiss_prot_ac": "O95477", "ftid": "VAR_062487", "type_of_variant": "LP/P",
+             "dbsnp_id": "rs137854496", "disease_name": None},
+        ]
+        docs = list(up.build_docs(coordinate_info, humsavar_rows))
+        # both consumed by the coordinate match -- no standalone leftovers
+        self.assertEqual(len(docs), 1)
+        humsavar = docs[0]["uniprot"]["humsavar"]
         self.assertIsInstance(humsavar, list)
         self.assertEqual({h["ftid"] for h in humsavar}, {"VAR_009147", "VAR_062487"})
-        self.assertEqual(sorted(doc["uniprot"]["source_db_id"]),
-                          ["RCV000010098", "RCV001509362", "rs137854496"])
 
     def test_no_extra_fields_beyond_existing_mapping(self):
-        """Standing decision: no Evidence/Consequence Type/etc. fields are ever added."""
         coordinate_info = {
             "NC_000019.10:g.58864491G>A": {
                 "source_db_id": {"rs893184"}, "clinical_significance": {"Pathogenic"},
                 "phenotype_disease": {"Some phenotype"}, "phenotype_disease_source": {"MIM:12345"},
             }
         }
-        humsavar_index = {"rs893184": [{"swiss_prot_ac": "P04217", "ftid": "VAR_018369",
-                                         "type_of_variant": "LB/B", "disease_name": "Some disease"}]}
-        doc = next(iter(up.build_docs(coordinate_info, humsavar_index)))
+        humsavar_rows = [{"swiss_prot_ac": "P04217", "ftid": "VAR_018369", "type_of_variant": "LB/B",
+                          "dbsnp_id": "rs893184", "disease_name": "Some disease"}]
+        doc = next(iter(up.build_docs(coordinate_info, humsavar_rows)))
         self.assertEqual(set(doc["uniprot"].keys()), {
             "humsavar", "source_db_id", "clinical_significance",
             "phenotype_disease", "phenotype_disease_source",
-        })
-        self.assertEqual(set(doc["uniprot"]["humsavar"].keys()), {
-            "swiss_prot_ac", "ftid", "type_of_variant", "disease_name",
         })
 
 
@@ -389,52 +330,52 @@ class TestBuildDocs(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 class TestMergeDocs(unittest.TestCase):
+    """
+    Regression test for a real production crash: two distinct humsavar.txt
+    records for ABCA1 (VAR_009147 p.Trp590Ser and VAR_062487 p.Trp590Leu) both
+    reference the same dbSNP id, rs137854496. Both resolve to the same
+    genomic coordinate (chr9:g.104831048C>G), so build_docs() can yield two
+    documents with the same _id. Storage does a plain insert (not upsert),
+    so without merging this crashes the whole batch with a MongoDB E11000
+    duplicate key error.
+    """
 
-    def test_non_colliding_docs_pass_through_unchanged(self):
-        doc_a = {"_id": "chr1:g.1A>G", "uniprot": {"source_db_id": "rs1"}}
-        doc_b = {"_id": "chr2:g.2A>G", "uniprot": {"source_db_id": "rs2"}}
-        docs = list(up.merge_docs([doc_a, doc_b]))
-        self.assertEqual(len(docs), 2)
-        self.assertIn(doc_a, docs)
-        self.assertIn(doc_b, docs)
+    def setUp(self):
+        self.doc_a = {
+            "_id": "chr9:g.104831048C>G",
+            "uniprot": {
+                "humsavar": {"swiss_prot_ac": "O95477", "ftid": "VAR_009147", "type_of_variant": "LP/P"},
+                "source_db_id": "rs137854496",
+            },
+        }
+        self.doc_b = {
+            "_id": "chr9:g.104831048C>G",
+            "uniprot": {
+                "humsavar": {"swiss_prot_ac": "O95477", "ftid": "VAR_062487", "type_of_variant": "LP/P"},
+                "source_db_id": ["RCV000010098", "rs137854496"],
+                "clinical_significance": "Pathogenic",
+            },
+        }
 
-    def test_colliding_docs_merge_into_one_and_union_source_db_id(self):
-        doc_a = {"_id": "chr9:g.104831048C>G", "uniprot": {"source_db_id": "rs137854496"}}
-        doc_b = {"_id": "chr9:g.104831048C>G", "uniprot": {"source_db_id": ["RCV000010098", "rs137854496"]}}
-        docs = list(up.merge_docs([doc_a, doc_b]))
-        self.assertEqual(len(docs), 1, "must not crash storage with two docs sharing an _id")
-        self.assertEqual(sorted(docs[0]["uniprot"]["source_db_id"]),
-                          ["RCV000010098", "rs137854496"])
+    def test_colliding_docs_produce_a_single_document(self):
+        docs = list(up.merge_docs([self.doc_a, self.doc_b]))
+        self.assertEqual(len(docs), 1)
 
-    def test_colliding_docs_union_humsavar_records(self):
-        doc_a = {"_id": "chr9:g.104831048C>G",
-                 "uniprot": {"humsavar": {"ftid": "VAR_009147", "swiss_prot_ac": "O95477",
-                                           "type_of_variant": "LP/P"}}}
-        doc_b = {"_id": "chr9:g.104831048C>G",
-                 "uniprot": {"humsavar": {"ftid": "VAR_062487", "swiss_prot_ac": "O95477",
-                                           "type_of_variant": "LP/P"}}}
-        merged = next(iter(up.merge_docs([doc_a, doc_b])))
+    def test_humsavar_becomes_a_list_of_both_records(self):
+        merged = next(iter(up.merge_docs([self.doc_a, self.doc_b])))
         humsavar = merged["uniprot"]["humsavar"]
         self.assertIsInstance(humsavar, list)
         self.assertEqual({h["ftid"] for h in humsavar}, {"VAR_009147", "VAR_062487"})
 
-    def test_one_doc_with_humsavar_one_without_still_merges(self):
-        doc_a = {"_id": "chr1:g.1A>G", "uniprot": {"source_db_id": "rs1"}}
-        doc_b = {"_id": "chr1:g.1A>G",
-                 "uniprot": {"source_db_id": "rs2",
-                             "humsavar": {"ftid": "VAR_1", "swiss_prot_ac": "P1", "type_of_variant": "US"}}}
-        merged = next(iter(up.merge_docs([doc_a, doc_b])))
-        self.assertEqual(merged["uniprot"]["humsavar"], {
-            "ftid": "VAR_1", "swiss_prot_ac": "P1", "type_of_variant": "US",
-        })
-        self.assertEqual(sorted(merged["uniprot"]["source_db_id"]), ["rs1", "rs2"])
+    def test_source_db_id_unioned(self):
+        merged = next(iter(up.merge_docs([self.doc_a, self.doc_b])))
+        self.assertEqual(sorted(merged["uniprot"]["source_db_id"]),
+                          ["RCV000010098", "rs137854496"])
 
-    def test_single_doc_group_keeps_humsavar_as_a_plain_dict(self):
-        doc_a = {"_id": "chr1:g.1A>G",
-                 "uniprot": {"humsavar": {"ftid": "VAR_1", "swiss_prot_ac": "P1", "type_of_variant": "US"}}}
-        docs = list(up.merge_docs([doc_a]))
-        self.assertEqual(len(docs), 1)
-        self.assertIsInstance(docs[0]["uniprot"]["humsavar"], dict)
+    def test_non_colliding_docs_pass_through_unchanged(self):
+        other = {"_id": "chr1:g.1A>G", "uniprot": {"humsavar": {"ftid": "VAR_1"}}}
+        docs = list(up.merge_docs([self.doc_a, other]))
+        self.assertEqual(len(docs), 2)
 
 
 # ---------------------------------------------------------------------------
@@ -451,12 +392,13 @@ class TestLoadDataIntegration(unittest.TestCase):
 
         with open(os.path.join(self.tmpdir, up.HUMSAVAR_FILE), "w") as f:
             f.writelines(_HUMSAVAR_PREAMBLE)
-            # matches a variation-file row below -> gets a humsavar field
+            # matches a variation-file row below -> document with both files' data
             f.write("A1BG        P04217     VAR_018369  p.His52Arg     LB/B     rs893184       -\n")
-            # dbSNP id not present anywhere in the variation file -> no effect on output
-            f.write("A1BG        P04217     VAR_018370  p.His395Arg    LB/B     rs_not_in_variation_file      -\n")
+            # no dbSNP id at all -> standalone document
+            f.write("AARS1       P49588     VAR_073293  p.Thr608Met    US       -              -\n")
+            # has a dbSNP id, but it's absent from the variation file -> standalone document
+            f.write("ZZZ1        Q00000     VAR_999999  p.Ala1Val      US       rs_not_in_variation_file  -\n")
             # regression case: two distinct humsavar records sharing one dbSNP id
-            # (real production case: ABCA1 VAR_009147/VAR_062487 both rs137854496)
             f.write("ABCA1       O95477     VAR_009147  p.Trp590Ser    LP/P     rs137854496    "
                     "Tangier disease (TGD) [MIM:205400]\n")
             f.write("ABCA1       O95477     VAR_062487  p.Trp590Leu    LP/P     rs137854496    "
@@ -465,15 +407,12 @@ class TestLoadDataIntegration(unittest.TestCase):
         variation_path = os.path.join(self.tmpdir, "homo_sapiens_variation.txt.gz")
         with gzip.open(variation_path, "wt") as f:
             f.writelines(_VARIATION_PREAMBLE)
-            # this coordinate matches humsavar's rs893184
-            f.write(_variation_row("rs893184", "NC_000019.10:g.58864491G>A",
-                                    gene="A1BG", aa="p.His52Arg"))
+            f.write(_variation_row("rs893184", "NC_000019.10:g.58864491G>A", gene="A1BG", aa="p.His52Arg"))
             f.write(_variation_row("RCV000012345", "NC_000019.10:g.58864491G>A",
                                     clinsig="Benign", gene="A1BG", aa="p.His52Arg"))
-            # this coordinate has NO humsavar match at all -- the new common case
+            # coordinate with no humsavar match at all
             f.write(_variation_row("rs999999999", "NC_000002.12:g.500A>T",
-                                    gene="OTHERGENE", ac="Q00000", aa="p.Ala1Val"))
-            # matches humsavar's duplicate-dbSNP-id case
+                                    gene="OTHERGENE", ac="Q11111", aa="p.Ala1Val"))
             f.write(_variation_row("rs137854496", "NC_000009.12:g.104831048C>G",
                                     clinsig="Pathogenic", gene="ABCA1", ac="O95477", aa="p.Trp590Ser"))
 
@@ -481,38 +420,38 @@ class TestLoadDataIntegration(unittest.TestCase):
         import shutil
         shutil.rmtree(self.tmpdir, ignore_errors=True)
 
-    def test_every_variation_coordinate_produces_a_document(self):
-        """The base file drives output now: all 3 coordinates in the fixture
-        appear, regardless of whether humsavar has anything for them."""
+    def test_every_variation_coordinate_and_every_humsavar_record_is_represented(self):
         docs = up.load_data(self.tmpdir)
-        self.assertEqual({d["_id"] for d in docs}, {
-            "chr19:g.58864491G>A", "chr2:g.500A>T", "chr9:g.104831048C>G",
-        })
+        # 3 variation coordinates (chr19, chr2, chr9 -- chr9 gets the merged
+        # ABCA1 humsavar pair) + 2 standalone humsavar-only documents
+        # (AARS1 with no dbSNP id, ZZZ1 with an unmatched one) = 5 total
+        self.assertEqual(len(docs), 5)
 
-    def test_coordinate_with_humsavar_match_is_enriched(self):
+    def test_document_with_data_from_both_files(self):
         docs = up.load_data(self.tmpdir)
         by_id = {d["_id"]: d for d in docs}
         doc = by_id["chr19:g.58864491G>A"]
-        self.assertEqual(sorted(doc["uniprot"]["source_db_id"]),
-                          ["RCV000012345", "rs893184"])
+        self.assertEqual(sorted(doc["uniprot"]["source_db_id"]), ["RCV000012345", "rs893184"])
         self.assertEqual(doc["uniprot"]["clinical_significance"], "Benign")
         self.assertEqual(doc["uniprot"]["humsavar"]["swiss_prot_ac"], "P04217")
 
-    def test_coordinate_without_humsavar_match_has_no_humsavar_field(self):
+    def test_variation_only_coordinate_has_no_humsavar(self):
         docs = up.load_data(self.tmpdir)
         by_id = {d["_id"]: d for d in docs}
         doc = by_id["chr2:g.500A>T"]
         self.assertNotIn("humsavar", doc["uniprot"])
-        self.assertEqual(doc["uniprot"]["source_db_id"], "rs999999999")
+
+    def test_unmatched_humsavar_records_are_standalone_not_dropped(self):
+        docs = up.load_data(self.tmpdir)
+        standalone = [d for d in docs if set(d["uniprot"].keys()) == {"humsavar"}]
+        self.assertEqual(len(standalone), 2)
+        self.assertEqual({d["uniprot"]["humsavar"]["ftid"] for d in standalone},
+                          {"VAR_073293", "VAR_999999"})
+        # random ids, not genomic coordinates
+        for d in standalone:
+            self.assertFalse(d["_id"].startswith("chr"))
 
     def test_duplicate_dbsnp_id_across_humsavar_records_is_merged_not_crashed(self):
-        """
-        Regression test for the production crash this was originally built to
-        fix: without the merge, two raw humsavar-derived records at the same
-        coordinate would either duplicate the _id (old design) or, in the new
-        design, both attach to the single coordinate doc and must be combined
-        into one 'humsavar' list rather than raising or overwriting silently.
-        """
         docs = up.load_data(self.tmpdir)
         by_id = {d["_id"]: d for d in docs}
         doc = by_id["chr9:g.104831048C>G"]
@@ -520,6 +459,11 @@ class TestLoadDataIntegration(unittest.TestCase):
         self.assertIsInstance(humsavar, list)
         self.assertEqual({h["ftid"] for h in humsavar}, {"VAR_009147", "VAR_062487"})
         self.assertEqual(doc["uniprot"]["clinical_significance"], "Pathogenic")
+
+    def test_all_ids_unique(self):
+        docs = up.load_data(self.tmpdir)
+        ids = [d["_id"] for d in docs]
+        self.assertEqual(len(ids), len(set(ids)))
 
     def test_missing_variation_file_raises(self):
         import tempfile

--- a/src/tests/data/test_uniprot_parser.py
+++ b/src/tests/data/test_uniprot_parser.py
@@ -1,0 +1,412 @@
+"""
+Unit tests for the 'uniprot' myvariant.info source parser.
+
+Background: humsavar.txt (manually curated missense variants) has no genomic
+coordinate of its own -- only a dbSNP id -- so it's enriched by looking up
+that dbSNP id in the much larger homo_sapiens_variation.txt.gz variant index,
+which does carry a genomic coordinate. Per-source decisions this parser
+implements (see conversation / commit history for the "why"):
+
+  1. humsavar.txt drives which variants are produced; it's enriched with
+     whatever homo_sapiens_variation.txt.gz reports at the matched genomic
+     position -- including rs (dbSNP), RCV (ClinVar) or any other source,
+     not just the one dbSNP id used to find that position.
+  2. humsavar.txt's variant-category vocabulary (now ACMG/AMP-style: LP/P,
+     LB/B, US) is stored as-is, not translated to the old Disease/
+     Polymorphism/Unclassified scheme.
+  3. No new fields (e.g. Evidence, Consequence Type) are added to the
+     existing mapping -- only source_db_id, clinical_significance,
+     phenotype_disease, phenotype_disease_source and the humsavar.* fields.
+"""
+import os
+import sys
+import unittest
+
+# Ensure src/ is on the path so hub modules are importable
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+import importlib.util
+
+# Load the parser directly to avoid triggering biothings hub initialisation
+# (which requires a running config) via the uniprot __init__.py.
+_PARSER_PATH = os.path.join(
+    os.path.dirname(__file__),
+    "..", "..", "hub", "dataload", "sources", "uniprot", "uniprot_parser.py"
+)
+_spec = importlib.util.spec_from_file_location("uniprot_parser", _PARSER_PATH)
+up = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(up)
+
+
+# ---------------------------------------------------------------------------
+# nc_coordinate_to_hgvs_id
+# ---------------------------------------------------------------------------
+
+class TestNcCoordinateToHgvsId(unittest.TestCase):
+
+    def test_autosome(self):
+        self.assertEqual(
+            up.nc_coordinate_to_hgvs_id("NC_000017.11:g.30178149A>G"),
+            "chr17:g.30178149A>G")
+
+    def test_chr1(self):
+        self.assertEqual(
+            up.nc_coordinate_to_hgvs_id("NC_000001.11:g.12345C>T"),
+            "chr1:g.12345C>T")
+
+    def test_chrX(self):
+        self.assertEqual(
+            up.nc_coordinate_to_hgvs_id("NC_000023.11:g.99A>T"),
+            "chrX:g.99A>T")
+
+    def test_chrY(self):
+        self.assertEqual(
+            up.nc_coordinate_to_hgvs_id("NC_000024.10:g.99A>T"),
+            "chrY:g.99A>T")
+
+    def test_mitochondrial(self):
+        self.assertEqual(
+            up.nc_coordinate_to_hgvs_id("NC_012920.1:g.1234A>G"),
+            "chrMT:g.1234A>G")
+
+    def test_assembly_patch_version_is_ignored(self):
+        """Only the accession prefix (before the dot) determines the chromosome,
+        so this is robust to GRCh38 patch version bumps."""
+        self.assertEqual(
+            up.nc_coordinate_to_hgvs_id("NC_000017.12:g.1A>G"),
+            "chr17:g.1A>G")
+
+    def test_unrecognized_accession_returns_none(self):
+        self.assertIsNone(up.nc_coordinate_to_hgvs_id("NC_999999.1:g.1A>G"))
+
+    def test_malformed_coordinate_returns_none(self):
+        self.assertIsNone(up.nc_coordinate_to_hgvs_id("garbage"))
+
+
+# ---------------------------------------------------------------------------
+# parse_humsavar
+# ---------------------------------------------------------------------------
+
+_HUMSAVAR_PREAMBLE = [
+    "Description: Index of human variants curated from literature reports\n",
+    "\n",
+    "Main        Swiss-Prot             AA             Variant\n",
+    "gene name   AC         FTId        change         category dbSNP          Disease name\n",
+    "_________   __________ ___________ ______________ ________ ______________ _____________________\n",
+]
+
+
+class TestParseHumsavar(unittest.TestCase):
+
+    def test_skips_preamble(self):
+        rows = list(up.parse_humsavar(_HUMSAVAR_PREAMBLE))
+        self.assertEqual(rows, [])
+
+    def test_parses_basic_row(self):
+        lines = _HUMSAVAR_PREAMBLE + [
+            "A1BG        P04217     VAR_018369  p.His52Arg     LB/B     rs893184       -\n",
+        ]
+        rows = list(up.parse_humsavar(lines))
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        self.assertEqual(row["swiss_prot_ac"], "P04217")
+        self.assertEqual(row["ftid"], "VAR_018369")
+        self.assertEqual(row["type_of_variant"], "LB/B")
+        self.assertEqual(row["dbsnp_id"], "rs893184")
+        self.assertIsNone(row["disease_name"])
+
+    def test_new_acmg_vocabulary_kept_as_is(self):
+        """Decision 2: the current LP/P/LB/B/US vocabulary is not translated."""
+        lines = _HUMSAVAR_PREAMBLE + [
+            "AAAS        Q9NRG9     VAR_012804  p.Gln15Lys     LP/P     rs121918549    "
+            "Achalasia-addisonianism-alacrima syndrome (AAAS) [MIM:231550]\n",
+        ]
+        row = next(iter(up.parse_humsavar(lines)))
+        self.assertEqual(row["type_of_variant"], "LP/P")
+        self.assertEqual(
+            row["disease_name"],
+            "Achalasia-addisonianism-alacrima syndrome (AAAS) [MIM:231550]")
+
+    def test_missing_dbsnp_id_is_none(self):
+        lines = _HUMSAVAR_PREAMBLE + [
+            "AARS1       P49588     VAR_073293  p.Thr608Met    US       -              -\n",
+        ]
+        row = next(iter(up.parse_humsavar(lines)))
+        self.assertIsNone(row["dbsnp_id"])
+        self.assertIsNone(row["disease_name"])
+
+    def test_blank_lines_are_skipped(self):
+        lines = _HUMSAVAR_PREAMBLE + [
+            "\n",
+            "A1BG        P04217     VAR_018369  p.His52Arg     LB/B     rs893184       -\n",
+            "\n",
+        ]
+        rows = list(up.parse_humsavar(lines))
+        self.assertEqual(len(rows), 1)
+
+
+# ---------------------------------------------------------------------------
+# parse_variation
+# ---------------------------------------------------------------------------
+
+_VARIATION_PREAMBLE = [
+    "Description:     Index of Protein Altering Variants (SO:0001818)\n",
+    "\n",
+    "######## VARIANT INDEX ########\n",
+    "Gene Name\tAC\tVariant AA Change\tSource DB ID\tConsequence Type\t"
+    "Clinical Significance\tPhenotype/Disease\tPhenotype/Disease Source\t"
+    "Cytogenetic Band\tChromosome Coordinate\tEnsembl gene ID\t"
+    "Ensembl transcript ID\tEnsembl translation ID\tEvidence\n",
+    "___________\t___________\t____________________\t________________\t"
+    "________________________\t______________________\t"
+    "________________________________________\t__________________________\t"
+    "__________________\t______________________\t________________________________\t"
+    "________________________________\t________________________________\t"
+    "________________________________\n",
+]
+
+
+def _variation_row(source_db_id, coordinate, clinsig="-", pheno="-", pheno_src="-",
+                    gene="NSRP1", ac="A0A024QZ33", aa="p.Lys30Glu"):
+    return "\t".join([
+        gene, ac, aa, source_db_id, "missense variant", clinsig, pheno, pheno_src,
+        "17q11.2", coordinate, "ENSG00000126653", "ENST00000612959",
+        "ENSP00000477862", "TOPMed,gnomAD",
+    ]) + "\n"
+
+
+class TestParseVariation(unittest.TestCase):
+
+    def test_skips_preamble(self):
+        rows = list(up.parse_variation(_VARIATION_PREAMBLE))
+        self.assertEqual(rows, [])
+
+    def test_parses_basic_row(self):
+        lines = _VARIATION_PREAMBLE + [
+            _variation_row("rs965203080", "NC_000017.11:g.30172593A>G"),
+        ]
+        rows = list(up.parse_variation(lines))
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["source_db_id"], "rs965203080")
+        self.assertEqual(rows[0]["coordinate"], "NC_000017.11:g.30172593A>G")
+
+    def test_short_malformed_row_is_skipped(self):
+        lines = _VARIATION_PREAMBLE + ["too\tshort\n"]
+        rows = list(up.parse_variation(lines))
+        self.assertEqual(rows, [])
+
+
+# ---------------------------------------------------------------------------
+# build_variation_index
+# ---------------------------------------------------------------------------
+
+class TestBuildVariationIndex(unittest.TestCase):
+    """
+    Grounded in a real record found in UniProt's current release: the NSRP1
+    variant p.Lys30Glu (chr17:g.30178149A>G) is reported by three different
+    sources at the exact same genomic coordinate: rs143842750 (dbSNP),
+    RCV004292335 and RCV004545615 (ClinVar) -- exactly the "rs and RCV and any
+    other one" case Decision 1 calls for.
+    """
+
+    def setUp(self):
+        self.rows = [
+            {"source_db_id": "rs143842750", "coordinate": "NC_000017.11:g.30178149A>G",
+             "clinical_significance": "-", "phenotype_disease": "-", "phenotype_disease_source": "-"},
+            {"source_db_id": "RCV004292335", "coordinate": "NC_000017.11:g.30178149A>G",
+             "clinical_significance": "-", "phenotype_disease": "-", "phenotype_disease_source": "-"},
+            {"source_db_id": "RCV004545615", "coordinate": "NC_000017.11:g.30178149A>G",
+             "clinical_significance": "Likely benign", "phenotype_disease": "NSRP1-related disorder",
+             "phenotype_disease_source": "RCV004545615"},
+            # unrelated variant elsewhere in the file -- must never leak into the index
+            {"source_db_id": "rs000000001", "coordinate": "NC_000001.11:g.111A>G",
+             "clinical_significance": "-", "phenotype_disease": "-", "phenotype_disease_source": "-"},
+        ]
+
+    def _factory(self):
+        return lambda: iter(self.rows)
+
+    def test_resolves_needed_dbsnp_id_to_coordinate(self):
+        dbsnp_to_coord, _ = up.build_variation_index(self._factory(), {"rs143842750"})
+        self.assertEqual(dbsnp_to_coord["rs143842750"], "NC_000017.11:g.30178149A>G")
+
+    def test_unneeded_dbsnp_id_not_resolved(self):
+        dbsnp_to_coord, _ = up.build_variation_index(self._factory(), {"rs143842750"})
+        self.assertNotIn("rs000000001", dbsnp_to_coord)
+
+    def test_unknown_dbsnp_id_absent_from_result(self):
+        dbsnp_to_coord, _ = up.build_variation_index(self._factory(), {"rs_not_in_file"})
+        self.assertNotIn("rs_not_in_file", dbsnp_to_coord)
+
+    def test_aggregates_all_source_db_ids_sharing_the_coordinate(self):
+        """Decision 1: include rs, RCV, and any other source_db_id at that position."""
+        _, coord_info = up.build_variation_index(self._factory(), {"rs143842750"})
+        info = coord_info["NC_000017.11:g.30178149A>G"]
+        self.assertEqual(info["source_db_id"],
+                          {"rs143842750", "RCV004292335", "RCV004545615"})
+
+    def test_aggregates_clinical_and_phenotype_fields(self):
+        _, coord_info = up.build_variation_index(self._factory(), {"rs143842750"})
+        info = coord_info["NC_000017.11:g.30178149A>G"]
+        self.assertEqual(info["clinical_significance"], {"Likely benign"})
+        self.assertEqual(info["phenotype_disease"], {"NSRP1-related disorder"})
+        self.assertEqual(info["phenotype_disease_source"], {"RCV004545615"})
+
+    def test_placeholder_dash_values_are_excluded(self):
+        """Most rows are '-' for these fields; they must not pollute the aggregate."""
+        _, coord_info = up.build_variation_index(self._factory(), {"rs143842750"})
+        info = coord_info["NC_000017.11:g.30178149A>G"]
+        self.assertNotIn("-", info["clinical_significance"])
+        self.assertNotIn("-", info["phenotype_disease"])
+        self.assertNotIn("-", info["phenotype_disease_source"])
+
+    def test_unrelated_coordinate_not_collected(self):
+        _, coord_info = up.build_variation_index(self._factory(), {"rs143842750"})
+        self.assertNotIn("NC_000001.11:g.111A>G", coord_info)
+
+
+# ---------------------------------------------------------------------------
+# build_docs
+# ---------------------------------------------------------------------------
+
+class TestBuildDocs(unittest.TestCase):
+
+    def test_row_without_dbsnp_id_is_skipped(self):
+        humsavar_rows = [{
+            "swiss_prot_ac": "P00000", "ftid": "VAR_000001", "type_of_variant": "US",
+            "dbsnp_id": None, "disease_name": None,
+        }]
+        docs = list(up.build_docs(humsavar_rows, {}, {}))
+        self.assertEqual(docs, [])
+
+    def test_unresolved_dbsnp_id_is_skipped(self):
+        humsavar_rows = [{
+            "swiss_prot_ac": "P00000", "ftid": "VAR_000001", "type_of_variant": "US",
+            "dbsnp_id": "rs_unresolved", "disease_name": None,
+        }]
+        docs = list(up.build_docs(humsavar_rows, {}, {}))
+        self.assertEqual(docs, [])
+
+    def test_resolved_row_produces_expected_doc(self):
+        humsavar_rows = [{
+            "swiss_prot_ac": "P04217", "ftid": "VAR_018369", "type_of_variant": "LB/B",
+            "dbsnp_id": "rs893184", "disease_name": None,
+        }]
+        dbsnp_to_coord = {"rs893184": "NC_000019.10:g.58864491G>A"}
+        coord_info = {"NC_000019.10:g.58864491G>A": {
+            "source_db_id": {"rs893184"},
+            "clinical_significance": set(),
+            "phenotype_disease": set(),
+            "phenotype_disease_source": set(),
+        }}
+        docs = list(up.build_docs(humsavar_rows, dbsnp_to_coord, coord_info))
+        self.assertEqual(len(docs), 1)
+        doc = docs[0]
+        self.assertEqual(doc["_id"], "chr19:g.58864491G>A")
+        self.assertEqual(doc["uniprot"]["humsavar"], {
+            "swiss_prot_ac": "P04217", "ftid": "VAR_018369", "type_of_variant": "LB/B",
+        })
+        # single value -> unlist() collapses it to a scalar, matching prod's shape
+        self.assertEqual(doc["uniprot"]["source_db_id"], "rs893184")
+
+    def test_multi_valued_source_db_id_stays_a_sorted_list(self):
+        """Mirrors the real NSRP1 p.Lys30Glu case: rs + 2 RCV ids at one position."""
+        humsavar_rows = [{
+            "swiss_prot_ac": "A0A024QZ33", "ftid": "VAR_999999", "type_of_variant": "LB/B",
+            "dbsnp_id": "rs143842750", "disease_name": None,
+        }]
+        dbsnp_to_coord = {"rs143842750": "NC_000017.11:g.30178149A>G"}
+        coord_info = {"NC_000017.11:g.30178149A>G": {
+            "source_db_id": {"rs143842750", "RCV004292335", "RCV004545615"},
+            "clinical_significance": {"Likely benign"},
+            "phenotype_disease": {"NSRP1-related disorder"},
+            "phenotype_disease_source": {"RCV004545615"},
+        }}
+        doc = next(iter(up.build_docs(humsavar_rows, dbsnp_to_coord, coord_info)))
+        self.assertEqual(doc["_id"], "chr17:g.30178149A>G")
+        self.assertEqual(sorted(doc["uniprot"]["source_db_id"]),
+                          ["RCV004292335", "RCV004545615", "rs143842750"])
+        self.assertEqual(doc["uniprot"]["clinical_significance"], "Likely benign")
+
+    def test_no_extra_fields_beyond_existing_mapping(self):
+        """Decision 3: no Evidence/Consequence Type/etc. fields are ever added."""
+        humsavar_rows = [{
+            "swiss_prot_ac": "P04217", "ftid": "VAR_018369", "type_of_variant": "LB/B",
+            "dbsnp_id": "rs893184", "disease_name": "Some disease",
+        }]
+        dbsnp_to_coord = {"rs893184": "NC_000019.10:g.58864491G>A"}
+        coord_info = {"NC_000019.10:g.58864491G>A": {
+            "source_db_id": {"rs893184"},
+            "clinical_significance": {"Pathogenic"},
+            "phenotype_disease": {"Some phenotype"},
+            "phenotype_disease_source": {"MIM:12345"},
+        }}
+        doc = next(iter(up.build_docs(humsavar_rows, dbsnp_to_coord, coord_info)))
+        self.assertEqual(set(doc["uniprot"].keys()), {
+            "humsavar", "source_db_id", "clinical_significance",
+            "phenotype_disease", "phenotype_disease_source",
+        })
+        self.assertEqual(set(doc["uniprot"]["humsavar"].keys()), {
+            "swiss_prot_ac", "ftid", "type_of_variant", "disease_name",
+        })
+
+
+# ---------------------------------------------------------------------------
+# load_data (integration)
+# ---------------------------------------------------------------------------
+
+class TestLoadDataIntegration(unittest.TestCase):
+
+    def setUp(self):
+        import tempfile
+        import gzip
+
+        self.tmpdir = tempfile.mkdtemp()
+
+        with open(os.path.join(self.tmpdir, up.HUMSAVAR_FILE), "w") as f:
+            f.writelines(_HUMSAVAR_PREAMBLE)
+            # resolvable row (matches a variation-file row below)
+            f.write("A1BG        P04217     VAR_018369  p.His52Arg     LB/B     rs893184       -\n")
+            # unresolvable row: no matching entry in the variation file
+            f.write("A1BG        P04217     VAR_018370  p.His395Arg    LB/B     rs2241788      -\n")
+            # unresolvable row: no dbSNP id at all
+            f.write("AARS1       P49588     VAR_073293  p.Thr608Met    US       -              -\n")
+
+        variation_path = os.path.join(self.tmpdir, "homo_sapiens_variation.txt.gz")
+        with gzip.open(variation_path, "wt") as f:
+            f.writelines(_VARIATION_PREAMBLE)
+            f.write(_variation_row("rs893184", "NC_000019.10:g.58864491G>A",
+                                    gene="A1BG", aa="p.His52Arg"))
+            # a second source at that same position, to exercise aggregation end-to-end
+            f.write(_variation_row("RCV000012345", "NC_000019.10:g.58864491G>A",
+                                    clinsig="Benign", gene="A1BG", aa="p.His52Arg"))
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_end_to_end(self):
+        docs = up.load_data(self.tmpdir)
+        self.assertEqual(len(docs), 1)
+        doc = docs[0]
+        self.assertEqual(doc["_id"], "chr19:g.58864491G>A")
+        self.assertEqual(sorted(doc["uniprot"]["source_db_id"]),
+                          ["RCV000012345", "rs893184"])
+        self.assertEqual(doc["uniprot"]["clinical_significance"], "Benign")
+        self.assertEqual(doc["uniprot"]["humsavar"]["swiss_prot_ac"], "P04217")
+
+    def test_missing_variation_file_raises(self):
+        import tempfile
+        empty_dir = tempfile.mkdtemp()
+        try:
+            with open(os.path.join(empty_dir, up.HUMSAVAR_FILE), "w") as f:
+                f.writelines(_HUMSAVAR_PREAMBLE)
+            with self.assertRaises(AssertionError):
+                up.load_data(empty_dir)
+        finally:
+            import shutil
+            shutil.rmtree(empty_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tests/data/test_uniprot_parser.py
+++ b/src/tests/data/test_uniprot_parser.py
@@ -2,15 +2,20 @@
 Unit tests for the 'uniprot' myvariant.info source parser.
 
 Architecture (per direct decision from the source owner): load ALL data from
-both humsavar.txt and homo_sapiens_variation.txt.gz, connecting records that
-relate to each other:
+both humsavar.txt and homo_sapiens_variation.txt.gz -- every column from
+both files, not just a curated subset -- connecting records that relate to
+each other:
 
   - Every unique genomic coordinate in homo_sapiens_variation.txt.gz becomes
-    a document, enriched with whatever source_db_id/clinical_significance/
-    phenotype_disease/phenotype_disease_source values UniProt reports there.
+    a document, populated with every column UniProt reports there (gene
+    name, AC, AA change, source_db_id, consequence_type,
+    clinical_significance, phenotype_disease, phenotype_disease_source,
+    cytogenetic_band, and the Ensembl gene/transcript/translation ids and
+    evidence sources), aggregated across every row sharing the coordinate.
   - Every humsavar.txt record whose dbSNP id matches one of a coordinate's
-    source_db_id values gets attached to that coordinate's document -- these
-    are the documents with data from both files.
+    source_db_id values gets attached to that coordinate's document (with
+    its own gene name, Swiss-Prot AC, FTId, AA change, variant category and
+    disease name) -- these are the documents with data from both files.
   - Every humsavar.txt record that never matches anything (no dbSNP id, or
     a dbSNP id absent from the variation file -- about 17% of humsavar.txt)
     still becomes its own standalone document, with a random _id (no
@@ -20,9 +25,6 @@ Other standing decisions this parser implements:
   - humsavar.txt's variant-category vocabulary (now ACMG/AMP-style: LP/P,
     LB/B, US) is stored as-is, not translated to the old Disease/
     Polymorphism/Unclassified scheme.
-  - No new fields (e.g. Evidence, Consequence Type) are added to the
-    existing mapping -- only source_db_id, clinical_significance,
-    phenotype_disease, phenotype_disease_source and the humsavar.* fields.
 """
 import os
 import sys
@@ -112,11 +114,13 @@ _VARIATION_PREAMBLE = [
 
 
 def _variation_row(source_db_id, coordinate, clinsig="-", pheno="-", pheno_src="-",
-                    gene="NSRP1", ac="A0A024QZ33", aa="p.Lys30Glu"):
+                    gene="NSRP1", ac="A0A024QZ33", aa="p.Lys30Glu",
+                    consequence="missense variant", cyto="17q11.2",
+                    ensg="ENSG00000126653", enst="ENST00000612959",
+                    ensp="ENSP00000477862", evidence="TOPMed,gnomAD"):
     return "\t".join([
-        gene, ac, aa, source_db_id, "missense variant", clinsig, pheno, pheno_src,
-        "17q11.2", coordinate, "ENSG00000126653", "ENST00000612959",
-        "ENSP00000477862", "TOPMed,gnomAD",
+        gene, ac, aa, source_db_id, consequence, clinsig, pheno, pheno_src,
+        cyto, coordinate, ensg, enst, ensp, evidence,
     ]) + "\n"
 
 
@@ -125,13 +129,15 @@ class TestParseHumsavar(unittest.TestCase):
     def test_skips_preamble(self):
         self.assertEqual(list(up.parse_humsavar(_HUMSAVAR_PREAMBLE)), [])
 
-    def test_parses_basic_row(self):
+    def test_parses_all_columns(self):
         lines = _HUMSAVAR_PREAMBLE + [
             "A1BG        P04217     VAR_018369  p.His52Arg     LB/B     rs893184       -\n",
         ]
         row = next(iter(up.parse_humsavar(lines)))
+        self.assertEqual(row["gene_name"], "A1BG")
         self.assertEqual(row["swiss_prot_ac"], "P04217")
         self.assertEqual(row["ftid"], "VAR_018369")
+        self.assertEqual(row["aa_change"], "p.His52Arg")
         self.assertEqual(row["type_of_variant"], "LB/B")
         self.assertEqual(row["dbsnp_id"], "rs893184")
         self.assertIsNone(row["disease_name"])
@@ -160,14 +166,35 @@ class TestParseVariation(unittest.TestCase):
     def test_skips_preamble(self):
         self.assertEqual(list(up.parse_variation(_VARIATION_PREAMBLE)), [])
 
-    def test_parses_basic_row(self):
+    def test_parses_all_14_columns(self):
         lines = _VARIATION_PREAMBLE + [_variation_row("rs965203080", "NC_000017.11:g.30172593A>G")]
         row = next(iter(up.parse_variation(lines)))
-        self.assertEqual(row["source_db_id"], "rs965203080")
-        self.assertEqual(row["coordinate"], "NC_000017.11:g.30172593A>G")
+        self.assertEqual(row, {
+            "gene_name": "NSRP1",
+            "swiss_prot_ac": "A0A024QZ33",
+            "aa_change": "p.Lys30Glu",
+            "source_db_id": "rs965203080",
+            "consequence_type": "missense variant",
+            "clinical_significance": "-",
+            "phenotype_disease": "-",
+            "phenotype_disease_source": "-",
+            "cytogenetic_band": "17q11.2",
+            "coordinate": "NC_000017.11:g.30172593A>G",
+            "ensembl_gene_id": "ENSG00000126653",
+            "ensembl_transcript_id": "ENST00000612959",
+            "ensembl_translation_id": "ENSP00000477862",
+            "evidence": "TOPMed,gnomAD",
+        })
 
     def test_short_malformed_row_is_skipped(self):
         lines = _VARIATION_PREAMBLE + ["too\tshort\n"]
+        self.assertEqual(list(up.parse_variation(lines)), [])
+
+    def test_row_with_fewer_than_14_columns_is_skipped(self):
+        """The old 10-column threshold would have let a truncated row with only
+        the first 10 fields through; all 14 are now required."""
+        lines = _VARIATION_PREAMBLE + ["\t".join(["g", "ac", "aa", "rs1", "missense variant",
+                                                   "-", "-", "-", "17q11.2", "NC_000017.11:g.1A>G"]) + "\n"]
         self.assertEqual(list(up.parse_variation(lines)), [])
 
 
@@ -184,17 +211,21 @@ class TestBuildVariationAggregate(unittest.TestCase):
     """
 
     def setUp(self):
-        self.rows = [
-            {"source_db_id": "rs143842750", "coordinate": "NC_000017.11:g.30178149A>G",
-             "clinical_significance": "-", "phenotype_disease": "-", "phenotype_disease_source": "-"},
-            {"source_db_id": "RCV004292335", "coordinate": "NC_000017.11:g.30178149A>G",
-             "clinical_significance": "-", "phenotype_disease": "-", "phenotype_disease_source": "-"},
-            {"source_db_id": "RCV004545615", "coordinate": "NC_000017.11:g.30178149A>G",
-             "clinical_significance": "Likely benign", "phenotype_disease": "NSRP1-related disorder",
-             "phenotype_disease_source": "RCV004545615"},
-            {"source_db_id": "rs000000001", "coordinate": "NC_000001.11:g.111A>G",
-             "clinical_significance": "-", "phenotype_disease": "-", "phenotype_disease_source": "-"},
-        ]
+        base = {
+            "gene_name": "NSRP1", "swiss_prot_ac": "A0A024QZ33", "aa_change": "p.Lys30Glu",
+            "consequence_type": "missense variant", "cytogenetic_band": "17q11.2",
+            "ensembl_gene_id": "ENSG00000126653", "ensembl_transcript_id": "ENST00000612959",
+            "ensembl_translation_id": "ENSP00000477862", "evidence": "TOPMed,gnomAD",
+            "clinical_significance": "-", "phenotype_disease": "-", "phenotype_disease_source": "-",
+        }
+        row1 = dict(base, source_db_id="rs143842750", coordinate="NC_000017.11:g.30178149A>G")
+        row2 = dict(base, source_db_id="RCV004292335", coordinate="NC_000017.11:g.30178149A>G",
+                    ensembl_transcript_id="ENST00000999999")  # a different transcript, same coordinate
+        row3 = dict(base, source_db_id="RCV004545615", coordinate="NC_000017.11:g.30178149A>G",
+                    clinical_significance="Likely benign", phenotype_disease="NSRP1-related disorder",
+                    phenotype_disease_source="RCV004545615")
+        row4 = dict(base, source_db_id="rs000000001", coordinate="NC_000001.11:g.111A>G")
+        self.rows = [row1, row2, row3, row4]
 
     def test_every_coordinate_becomes_a_key(self):
         coordinate_info = up.build_variation_aggregate(self.rows)
@@ -207,6 +238,16 @@ class TestBuildVariationAggregate(unittest.TestCase):
         info = coordinate_info["NC_000017.11:g.30178149A>G"]
         self.assertEqual(info["source_db_id"], {"rs143842750", "RCV004292335", "RCV004545615"})
 
+    def test_aggregates_new_fields_across_rows_sharing_a_coordinate(self):
+        """Two different Ensembl transcripts at the same coordinate must both
+        be collected, not just the first one seen."""
+        coordinate_info = up.build_variation_aggregate(self.rows)
+        info = coordinate_info["NC_000017.11:g.30178149A>G"]
+        self.assertEqual(info["ensembl_transcript_id"], {"ENST00000612959", "ENST00000999999"})
+        self.assertEqual(info["gene_name"], {"NSRP1"})
+        self.assertEqual(info["cytogenetic_band"], {"17q11.2"})
+        self.assertEqual(info["evidence"], {"TOPMed,gnomAD"})
+
     def test_placeholder_dash_values_are_excluded(self):
         coordinate_info = up.build_variation_aggregate(self.rows)
         info = coordinate_info["NC_000017.11:g.30178149A>G"]
@@ -217,111 +258,100 @@ class TestBuildVariationAggregate(unittest.TestCase):
 # build_docs
 # ---------------------------------------------------------------------------
 
+def _coord_info(**overrides):
+    info = {key: set() for key in up._ALL_VARIATION_FIELDS}
+    for key, value in overrides.items():
+        info[key] = value
+    return info
+
+
+def _humsavar_row(gene_name="P1", swiss_prot_ac="P00000", ftid="VAR_000001", aa_change="p.X1Y",
+                   type_of_variant="US", dbsnp_id=None, disease_name=None):
+    return {
+        "gene_name": gene_name, "swiss_prot_ac": swiss_prot_ac, "ftid": ftid,
+        "aa_change": aa_change, "type_of_variant": type_of_variant,
+        "dbsnp_id": dbsnp_id, "disease_name": disease_name,
+    }
+
+
 class TestBuildDocs(unittest.TestCase):
 
-    def test_coordinate_with_no_humsavar_match_has_no_humsavar_field(self):
-        coordinate_info = {
-            "NC_000001.11:g.111A>G": {
-                "source_db_id": {"rs000000001"}, "clinical_significance": set(),
-                "phenotype_disease": set(), "phenotype_disease_source": set(),
-            }
-        }
+    def test_coordinate_with_no_humsavar_match_has_all_variation_fields_and_no_humsavar(self):
+        coordinate_info = {"NC_000001.11:g.111A>G": _coord_info(
+            source_db_id={"rs000000001"}, gene_name={"OTHERGENE"}, cytogenetic_band={"1p36.33"})}
         docs = list(up.build_docs(coordinate_info, []))
         self.assertEqual(len(docs), 1)
-        self.assertEqual(docs[0]["_id"], "chr1:g.111A>G")
-        self.assertNotIn("humsavar", docs[0]["uniprot"])
+        doc = docs[0]
+        self.assertEqual(doc["_id"], "chr1:g.111A>G")
+        self.assertNotIn("humsavar", doc["uniprot"])
+        self.assertEqual(doc["uniprot"]["gene_name"], "OTHERGENE")
+        self.assertEqual(doc["uniprot"]["cytogenetic_band"], "1p36.33")
 
-    def test_humsavar_attached_when_dbsnp_id_matches(self):
-        """A document with data from both files."""
-        coordinate_info = {
-            "NC_000019.10:g.58864491G>A": {
-                "source_db_id": {"rs893184"}, "clinical_significance": set(),
-                "phenotype_disease": set(), "phenotype_disease_source": set(),
-            }
-        }
-        humsavar_rows = [{"swiss_prot_ac": "P04217", "ftid": "VAR_018369",
-                          "type_of_variant": "LB/B", "dbsnp_id": "rs893184", "disease_name": None}]
+    def test_humsavar_attached_when_dbsnp_id_matches_includes_gene_name_and_aa_change(self):
+        """A document with data from both files, including the newly added
+        humsavar.gene_name / humsavar.aa_change fields."""
+        coordinate_info = {"NC_000019.10:g.58864491G>A": _coord_info(source_db_id={"rs893184"})}
+        humsavar_rows = [_humsavar_row(gene_name="A1BG", swiss_prot_ac="P04217", ftid="VAR_018369",
+                                        aa_change="p.His52Arg", type_of_variant="LB/B", dbsnp_id="rs893184")]
         doc = next(iter(up.build_docs(coordinate_info, humsavar_rows)))
-        self.assertEqual(doc["uniprot"]["humsavar"],
-                          {"swiss_prot_ac": "P04217", "ftid": "VAR_018369", "type_of_variant": "LB/B"})
-        self.assertEqual(doc["uniprot"]["source_db_id"], "rs893184")
+        self.assertEqual(doc["uniprot"]["humsavar"], {
+            "gene_name": "A1BG", "swiss_prot_ac": "P04217", "ftid": "VAR_018369",
+            "aa_change": "p.His52Arg", "type_of_variant": "LB/B",
+        })
 
-    def test_unmatched_humsavar_row_becomes_standalone_document(self):
-        """Every humsavar record must end up as a document somewhere, even
-        with no dbSNP id at all -- the key new behavior vs. the earlier
-        variation-as-base design, which silently dropped these."""
-        humsavar_rows = [{"swiss_prot_ac": "P49588", "ftid": "VAR_073293",
-                          "type_of_variant": "US", "dbsnp_id": None, "disease_name": None}]
+    def test_unmatched_humsavar_row_becomes_standalone_document_with_all_fields(self):
+        humsavar_rows = [_humsavar_row(gene_name="AARS1", swiss_prot_ac="P49588", ftid="VAR_073293",
+                                        aa_change="p.Thr608Met", type_of_variant="US")]
         docs = list(up.build_docs({}, humsavar_rows))
         self.assertEqual(len(docs), 1)
         self.assertIn("_id", docs[0])
-        self.assertTrue(docs[0]["_id"])  # a random id, not a specific known value
+        self.assertTrue(docs[0]["_id"])
         self.assertEqual(docs[0]["uniprot"], {"humsavar": {
-            "swiss_prot_ac": "P49588", "ftid": "VAR_073293", "type_of_variant": "US",
+            "gene_name": "AARS1", "swiss_prot_ac": "P49588", "ftid": "VAR_073293",
+            "aa_change": "p.Thr608Met", "type_of_variant": "US",
         }})
 
     def test_humsavar_row_with_dbsnp_id_absent_from_variation_file_becomes_standalone(self):
-        """Has a dbSNP id, but it never appears in homo_sapiens_variation.txt.gz."""
-        coordinate_info = {
-            "NC_000001.11:g.111A>G": {
-                "source_db_id": {"rs_unrelated"}, "clinical_significance": set(),
-                "phenotype_disease": set(), "phenotype_disease_source": set(),
-            }
-        }
-        humsavar_rows = [{"swiss_prot_ac": "P00000", "ftid": "VAR_000001",
-                          "type_of_variant": "US", "dbsnp_id": "rs_not_in_variation_file", "disease_name": None}]
+        coordinate_info = {"NC_000001.11:g.111A>G": _coord_info(source_db_id={"rs_unrelated"})}
+        humsavar_rows = [_humsavar_row(ftid="VAR_000001", dbsnp_id="rs_not_in_variation_file")]
         docs = list(up.build_docs(coordinate_info, humsavar_rows))
         self.assertEqual(len(docs), 2)
         standalone = [d for d in docs if d["_id"] != "chr1:g.111A>G"][0]
         self.assertEqual(standalone["uniprot"]["humsavar"]["ftid"], "VAR_000001")
 
     def test_standalone_documents_get_distinct_random_ids(self):
-        humsavar_rows = [
-            {"swiss_prot_ac": "P1", "ftid": "VAR_1", "type_of_variant": "US", "dbsnp_id": None, "disease_name": None},
-            {"swiss_prot_ac": "P2", "ftid": "VAR_2", "type_of_variant": "US", "dbsnp_id": None, "disease_name": None},
-        ]
+        humsavar_rows = [_humsavar_row(ftid="VAR_1"), _humsavar_row(ftid="VAR_2")]
         docs = list(up.build_docs({}, humsavar_rows))
-        self.assertEqual(len(docs), 2)
         ids = {d["_id"] for d in docs}
         self.assertEqual(len(ids), 2)
-        self.assertTrue(all(isinstance(i, str) and i for i in ids))
 
     def test_multiple_humsavar_matches_at_one_coordinate_become_a_list(self):
         """Real production case: ABCA1's two FTIds both cite rs137854496, both
         of which end up attached (not standalone) since the id matches."""
-        coordinate_info = {
-            "NC_000009.12:g.104831048C>G": {
-                "source_db_id": {"rs137854496", "RCV000010098"},
-                "clinical_significance": {"Pathogenic"},
-                "phenotype_disease": set(), "phenotype_disease_source": set(),
-            }
-        }
+        coordinate_info = {"NC_000009.12:g.104831048C>G": _coord_info(
+            source_db_id={"rs137854496", "RCV000010098"}, clinical_significance={"Pathogenic"})}
         humsavar_rows = [
-            {"swiss_prot_ac": "O95477", "ftid": "VAR_009147", "type_of_variant": "LP/P",
-             "dbsnp_id": "rs137854496", "disease_name": None},
-            {"swiss_prot_ac": "O95477", "ftid": "VAR_062487", "type_of_variant": "LP/P",
-             "dbsnp_id": "rs137854496", "disease_name": None},
+            _humsavar_row(gene_name="ABCA1", swiss_prot_ac="O95477", ftid="VAR_009147",
+                          aa_change="p.Trp590Ser", type_of_variant="LP/P", dbsnp_id="rs137854496"),
+            _humsavar_row(gene_name="ABCA1", swiss_prot_ac="O95477", ftid="VAR_062487",
+                          aa_change="p.Trp590Leu", type_of_variant="LP/P", dbsnp_id="rs137854496"),
         ]
         docs = list(up.build_docs(coordinate_info, humsavar_rows))
-        # both consumed by the coordinate match -- no standalone leftovers
         self.assertEqual(len(docs), 1)
         humsavar = docs[0]["uniprot"]["humsavar"]
         self.assertIsInstance(humsavar, list)
         self.assertEqual({h["ftid"] for h in humsavar}, {"VAR_009147", "VAR_062487"})
+        self.assertEqual({h["aa_change"] for h in humsavar}, {"p.Trp590Ser", "p.Trp590Leu"})
 
-    def test_no_extra_fields_beyond_existing_mapping(self):
-        coordinate_info = {
-            "NC_000019.10:g.58864491G>A": {
-                "source_db_id": {"rs893184"}, "clinical_significance": {"Pathogenic"},
-                "phenotype_disease": {"Some phenotype"}, "phenotype_disease_source": {"MIM:12345"},
-            }
-        }
-        humsavar_rows = [{"swiss_prot_ac": "P04217", "ftid": "VAR_018369", "type_of_variant": "LB/B",
-                          "dbsnp_id": "rs893184", "disease_name": "Some disease"}]
+    def test_no_fields_beyond_the_known_set(self):
+        coordinate_info = {"NC_000019.10:g.58864491G>A": _coord_info(
+            source_db_id={"rs893184"}, clinical_significance={"Pathogenic"},
+            phenotype_disease={"Some phenotype"}, phenotype_disease_source={"MIM:12345"})}
+        humsavar_rows = [_humsavar_row(ftid="VAR_018369", dbsnp_id="rs893184", disease_name="Some disease")]
         doc = next(iter(up.build_docs(coordinate_info, humsavar_rows)))
-        self.assertEqual(set(doc["uniprot"].keys()), {
-            "humsavar", "source_db_id", "clinical_significance",
-            "phenotype_disease", "phenotype_disease_source",
+        self.assertEqual(set(doc["uniprot"].keys()) - set(up._ALL_VARIATION_FIELDS), {"humsavar"})
+        self.assertEqual(set(doc["uniprot"]["humsavar"].keys()), {
+            "gene_name", "swiss_prot_ac", "ftid", "aa_change", "type_of_variant", "disease_name",
         })
 
 
@@ -346,6 +376,7 @@ class TestMergeDocs(unittest.TestCase):
             "uniprot": {
                 "humsavar": {"swiss_prot_ac": "O95477", "ftid": "VAR_009147", "type_of_variant": "LP/P"},
                 "source_db_id": "rs137854496",
+                "gene_name": "ABCA1",
             },
         }
         self.doc_b = {
@@ -354,6 +385,7 @@ class TestMergeDocs(unittest.TestCase):
                 "humsavar": {"swiss_prot_ac": "O95477", "ftid": "VAR_062487", "type_of_variant": "LP/P"},
                 "source_db_id": ["RCV000010098", "rs137854496"],
                 "clinical_significance": "Pathogenic",
+                "gene_name": "ABCA1",
             },
         }
 
@@ -371,6 +403,10 @@ class TestMergeDocs(unittest.TestCase):
         merged = next(iter(up.merge_docs([self.doc_a, self.doc_b])))
         self.assertEqual(sorted(merged["uniprot"]["source_db_id"]),
                           ["RCV000010098", "rs137854496"])
+
+    def test_matching_new_field_values_collapse_to_a_scalar(self):
+        merged = next(iter(up.merge_docs([self.doc_a, self.doc_b])))
+        self.assertEqual(merged["uniprot"]["gene_name"], "ABCA1")
 
     def test_non_colliding_docs_pass_through_unchanged(self):
         other = {"_id": "chr1:g.1A>G", "uniprot": {"humsavar": {"ftid": "VAR_1"}}}
@@ -427,19 +463,23 @@ class TestLoadDataIntegration(unittest.TestCase):
         # (AARS1 with no dbSNP id, ZZZ1 with an unmatched one) = 5 total
         self.assertEqual(len(docs), 5)
 
-    def test_document_with_data_from_both_files(self):
+    def test_document_with_data_from_both_files_includes_new_fields(self):
         docs = up.load_data(self.tmpdir)
         by_id = {d["_id"]: d for d in docs}
         doc = by_id["chr19:g.58864491G>A"]
         self.assertEqual(sorted(doc["uniprot"]["source_db_id"]), ["RCV000012345", "rs893184"])
         self.assertEqual(doc["uniprot"]["clinical_significance"], "Benign")
+        self.assertEqual(doc["uniprot"]["gene_name"], "A1BG")
+        self.assertEqual(doc["uniprot"]["ensembl_gene_id"], "ENSG00000126653")
         self.assertEqual(doc["uniprot"]["humsavar"]["swiss_prot_ac"], "P04217")
+        self.assertEqual(doc["uniprot"]["humsavar"]["aa_change"], "p.His52Arg")
 
     def test_variation_only_coordinate_has_no_humsavar(self):
         docs = up.load_data(self.tmpdir)
         by_id = {d["_id"]: d for d in docs}
         doc = by_id["chr2:g.500A>T"]
         self.assertNotIn("humsavar", doc["uniprot"])
+        self.assertEqual(doc["uniprot"]["gene_name"], "OTHERGENE")
 
     def test_unmatched_humsavar_records_are_standalone_not_dropped(self):
         docs = up.load_data(self.tmpdir)
@@ -447,7 +487,6 @@ class TestLoadDataIntegration(unittest.TestCase):
         self.assertEqual(len(standalone), 2)
         self.assertEqual({d["uniprot"]["humsavar"]["ftid"] for d in standalone},
                           {"VAR_073293", "VAR_999999"})
-        # random ids, not genomic coordinates
         for d in standalone:
             self.assertFalse(d["_id"].startswith("chr"))
 

--- a/src/tests/data/test_uniprot_parser.py
+++ b/src/tests/data/test_uniprot_parser.py
@@ -352,6 +352,81 @@ class TestBuildDocs(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# merge_docs
+# ---------------------------------------------------------------------------
+
+class TestMergeDocs(unittest.TestCase):
+    """
+    Regression test for a real production crash: two distinct humsavar.txt
+    records for ABCA1 (VAR_009147 p.Trp590Ser and VAR_062487 p.Trp590Leu) both
+    reference the same dbSNP id, rs137854496 -- a UniProt curation duplicate
+    that was never cleaned up. Both resolve to the same genomic coordinate
+    (chr9:g.104831048C>G), so build_docs() yields two documents with the same
+    _id. Storage does a plain insert (not upsert), so without merging this
+    crashes the whole batch with a MongoDB E11000 duplicate key error.
+    """
+
+    def setUp(self):
+        self.doc_a = {
+            "_id": "chr9:g.104831048C>G",
+            "uniprot": {
+                "humsavar": {"swiss_prot_ac": "O95477", "ftid": "VAR_009147",
+                             "type_of_variant": "LP/P",
+                             "disease_name": "Tangier disease (TGD) [MIM:205400]"},
+                "source_db_id": "rs137854496",
+            },
+        }
+        self.doc_b = {
+            "_id": "chr9:g.104831048C>G",
+            "uniprot": {
+                "humsavar": {"swiss_prot_ac": "O95477", "ftid": "VAR_062487",
+                             "type_of_variant": "LP/P",
+                             "disease_name": "Tangier disease (TGD) [MIM:205400]"},
+                "source_db_id": ["RCV000010098", "RCV001509362", "rs137854496"],
+                "clinical_significance": "Variant of uncertain significance, Likely pathogenic, Pathogenic",
+                "phenotype_disease": ["Tangier disease (TGD)", "Tangier disease (tgd)"],
+                "phenotype_disease_source": "MIM:205400, 31751110, RCV000010098",
+            },
+        }
+
+    def test_non_colliding_docs_pass_through_unchanged(self):
+        other = {"_id": "chr1:g.1A>G", "uniprot": {"humsavar": {"ftid": "VAR_1"}}}
+        docs = list(up.merge_docs([self.doc_a, other]))
+        self.assertEqual(len(docs), 2)
+        self.assertIn(other, docs)
+
+    def test_colliding_docs_produce_a_single_document(self):
+        docs = list(up.merge_docs([self.doc_a, self.doc_b]))
+        self.assertEqual(len(docs), 1, "must not crash storage with two docs sharing an _id")
+        self.assertEqual(docs[0]["_id"], "chr9:g.104831048C>G")
+
+    def test_humsavar_becomes_a_list_of_both_records(self):
+        merged = next(iter(up.merge_docs([self.doc_a, self.doc_b])))
+        humsavar = merged["uniprot"]["humsavar"]
+        self.assertIsInstance(humsavar, list)
+        self.assertEqual({h["ftid"] for h in humsavar}, {"VAR_009147", "VAR_062487"})
+
+    def test_source_db_id_unioned_across_scalar_and_list_values(self):
+        """doc_a has a scalar source_db_id, doc_b has a list -- both must merge cleanly."""
+        merged = next(iter(up.merge_docs([self.doc_a, self.doc_b])))
+        self.assertEqual(sorted(merged["uniprot"]["source_db_id"]),
+                          ["RCV000010098", "RCV001509362", "rs137854496"])
+
+    def test_enrichment_fields_from_either_doc_are_preserved(self):
+        merged = next(iter(up.merge_docs([self.doc_a, self.doc_b])))
+        self.assertEqual(merged["uniprot"]["clinical_significance"],
+                          "Variant of uncertain significance, Likely pathogenic, Pathogenic")
+        self.assertEqual(sorted(merged["uniprot"]["phenotype_disease"]),
+                          ["Tangier disease (TGD)", "Tangier disease (tgd)"])
+
+    def test_single_doc_group_is_not_wrapped_in_extra_list(self):
+        """The overwhelmingly common case (no collision) must keep humsavar as a plain dict."""
+        docs = list(up.merge_docs([self.doc_a]))
+        self.assertEqual(len(docs), 1)
+        self.assertIsInstance(docs[0]["uniprot"]["humsavar"], dict)
+
+
+# ---------------------------------------------------------------------------
 # load_data (integration)
 # ---------------------------------------------------------------------------
 
@@ -371,6 +446,12 @@ class TestLoadDataIntegration(unittest.TestCase):
             f.write("A1BG        P04217     VAR_018370  p.His395Arg    LB/B     rs2241788      -\n")
             # unresolvable row: no dbSNP id at all
             f.write("AARS1       P49588     VAR_073293  p.Thr608Met    US       -              -\n")
+            # regression case: two distinct humsavar records sharing one dbSNP id
+            # (real production case: ABCA1 VAR_009147/VAR_062487 both rs137854496)
+            f.write("ABCA1       O95477     VAR_009147  p.Trp590Ser    LP/P     rs137854496    "
+                    "Tangier disease (TGD) [MIM:205400]\n")
+            f.write("ABCA1       O95477     VAR_062487  p.Trp590Leu    LP/P     rs137854496    "
+                    "Tangier disease (TGD) [MIM:205400]\n")
 
         variation_path = os.path.join(self.tmpdir, "homo_sapiens_variation.txt.gz")
         with gzip.open(variation_path, "wt") as f:
@@ -380,6 +461,8 @@ class TestLoadDataIntegration(unittest.TestCase):
             # a second source at that same position, to exercise aggregation end-to-end
             f.write(_variation_row("RCV000012345", "NC_000019.10:g.58864491G>A",
                                     clinsig="Benign", gene="A1BG", aa="p.His52Arg"))
+            f.write(_variation_row("rs137854496", "NC_000009.12:g.104831048C>G",
+                                    clinsig="Pathogenic", gene="ABCA1", ac="O95477", aa="p.Trp590Ser"))
 
     def tearDown(self):
         import shutil
@@ -387,13 +470,33 @@ class TestLoadDataIntegration(unittest.TestCase):
 
     def test_end_to_end(self):
         docs = up.load_data(self.tmpdir)
-        self.assertEqual(len(docs), 1)
-        doc = docs[0]
-        self.assertEqual(doc["_id"], "chr19:g.58864491G>A")
+        # 2 resolvable groups: the A1BG row, and the merged ABCA1 pair (the 2
+        # unresolvable/no-dbSNP-id rows are skipped, not 4 separate documents)
+        self.assertEqual(len(docs), 2)
+        by_id = {d["_id"]: d for d in docs}
+
+        doc = by_id["chr19:g.58864491G>A"]
         self.assertEqual(sorted(doc["uniprot"]["source_db_id"]),
                           ["RCV000012345", "rs893184"])
         self.assertEqual(doc["uniprot"]["clinical_significance"], "Benign")
         self.assertEqual(doc["uniprot"]["humsavar"]["swiss_prot_ac"], "P04217")
+
+    def test_end_to_end_merges_duplicate_dbsnp_id_across_humsavar_records(self):
+        """
+        Regression test for the production crash: without merge_docs(), this
+        scenario yields two raw documents with _id 'chr9:g.104831048C>G' and
+        crashes storage.process()'s plain insert_many() with E11000. Here it
+        must produce exactly one merged document instead.
+        """
+        docs = up.load_data(self.tmpdir)
+        by_id = {d["_id"]: d for d in docs}
+        self.assertIn("chr9:g.104831048C>G", by_id)
+        merged = by_id["chr9:g.104831048C>G"]
+        humsavar = merged["uniprot"]["humsavar"]
+        self.assertIsInstance(humsavar, list)
+        self.assertEqual({h["ftid"] for h in humsavar}, {"VAR_009147", "VAR_062487"})
+        self.assertEqual(merged["uniprot"]["source_db_id"], "rs137854496")
+        self.assertEqual(merged["uniprot"]["clinical_significance"], "Pathogenic")
 
     def test_missing_variation_file_raises(self):
         import tempfile

--- a/src/web/schema/datasource/dbnsfp.json
+++ b/src/web/schema/datasource/dbnsfp.json
@@ -1,5 +1,5 @@
 {
     "data_source_name": "dbnsfp",
-    "data_source_uri": "https://sites.google.com/site/jpopgen/dbNSFP",
+    "data_source_uri": "https://www.dbnsfp.org",
     "data_fields": "http://myvariant.info/metadata/fields?prefix=dbnsfp"
 }


### PR DESCRIPTION
## Summary

This branch covers four independent pieces of work I picked up while
going through recurring hub failures and a couple of upstream format
changes:

- **ClinVar**: migrate from the deprecated `ClinVarFullRelease` XML feed
  to the new `ClinVarRCVRelease` feed, including the `Classifications`
  schema change.
- **dbSNP**: fix two separate production failures in the FTP dumper
  (timeouts, then a pickling crash).
- **dbNSFP**: implement support for the 5.4a release.
- **UniProt**: replace the previous manual/`DummySourceUploader`-based
  loading with a real dumper + parser.

## ClinVar

NCBI retired `ClinVarFullRelease` XML in favor of `ClinVarRCVRelease`,
which also replaces the single `<ClinicalSignificance>` element with a
`<Classifications>` block (`GermlineClassification` /
`OncogenicityClassification` / `SomaticClinicalImpact` /
`NoClassification`).

- Updated `clinvar_dump.py` to pull from the new FTP path and XSD
  (`xsd_public/RCV/ClinVar_RCV.xsd`).
- Updated `clinvar_xml_parser.py`'s `GLOB_PATTERN` and added
  `_extract_classification()` to read clinical significance/review
  status/last-evaluated date from the new `Classifications` block,
  preferring `GermlineClassification` and falling back through the
  other classification types.
- Fixed a crash where a malformed `<ClinVarSet>` block raised an
  `lxml.etree.XMLSyntaxError` carrying an unpicklable `error_log`
  attribute, which broke returning the exception from the parser's
  worker process. Now re-raised as a plain `RuntimeError`.
- Added a `MAX_REF_ALT_LEN` guard in `snpeff_parser.py`: a handful of
  ClinVar records (e.g. large TTN deletions) span tens of kb, and
  building/sending that large a REF allele was crashing the snpEff
  subprocess outright instead of just failing to annotate. These are
  now skipped with a warning.
- Validated against real downloaded `ClinVarRCVRelease` data before
  considering this done.

## dbSNP

Two separate real failures in `dbsnp_dump.py`, fixed independently:

- FTP downloads were timing out on large files with no way to resume;
  added `FTP_TIMEOUT` plus a `download()` override that resumes via
  `retrbinary(..., rest=offset)` with retries, and added MD5
  verification against NCBI's `CHECKSUMS` file post-download.
- A separate pickling crash (`self.logger/self.src_dump` are lazy,
  Mongo-connection-backed `@property` accessors under biothings'
  `BaseDumper`) was re-arming an unpicklable pymongo connection when
  touched inside `post_download()`. Fixed by using the plain module
  logger there instead of `self.logger`.

## dbNSFP 5.4a

Implemented parsing/mapping support for the new dbNSFP 5.4a release
(`dbnsfp_parser_54a_v1.py` / `_v2.py`, matching mapping files), wired
into `dbnsfp_upload.py`, with accompanying tests
(`test_dbnsfp_parser_54a.py`).

## UniProt

Replaced the previous fully-manual loading with an actual
`uniprot_dump.py` (fetches `humsavar.txt` and
`homo_sapiens_variation.txt.gz`) and `uniprot_parser.py`.

Per the current requirements, the parser loads **all** records from
both files and connects them where they're related:

- Every unique genomic coordinate in `homo_sapiens_variation.txt.gz`
  becomes a document, populated with all 14 columns from that file,
  aggregated across every row sharing the coordinate (e.g. multiple
  transcripts or multiple sources at one position).
- `humsavar.txt` records are attached to a coordinate's document when
  their dbSNP id matches one of that coordinate's `source_db_id`
  values; unmatched humsavar records (no dbSNP id, or a dbSNP id not
  present in the variation file — about 17% of humsavar.txt) still
  become standalone documents rather than being dropped.
- `evidence` values are split on comma before aggregating, since a
  single row's evidence can itself be a comma-separated list of
  sources (e.g. `"UniProt,ClinVar,ClinGen,dbSNP,...")`; without
  splitting, that string ends up as one opaque value alongside other
  rows' individual source names for the same coordinate instead of
  deduplicating against them.
- Colliding `_id`s (rare RefSeq patch-version differences normalizing
  to the same id) are merged rather than left to crash the batch
  insert with a MongoDB duplicate-key error.
- `uniprot_upload.py`'s mapping was updated for all new fields.

Added `test_uniprot_parser.py` (39 tests) covering coordinate
normalization, both file parsers, aggregation, document building,
merging, and end-to-end integration.

Known follow-up, not yet done: re-validating this version of the
parser against the complete real ~59M-row `homo_sapiens_variation.txt.gz`
end-to-end (a bounded slice test passed; the full-file run is still
pending).

## Testing

- `test_uniprot_parser.py`: 39/39 passing.
- `test_dbnsfp_parser_54a.py`: added and passing.
- ClinVar and dbSNP changes validated manually against real downloaded
  data (no dedicated unit tests for the dump-layer fixes).
